### PR TITLE
Autodiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Interpolations = "0.13"
 NLsolve = "4.5"
-SpecialFunctions = "1.3"
 StaticArrays = "1"
+SpecialFunctions = "1.4"
 julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Interpolations = "0.13"

--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -18,6 +18,6 @@ module Korg
 
     include("continuum_opacity/continuum_opacity.jl") #Define continuum opacity functions.
     include("synthesize.jl")                          #solve radiative transfer equation
-    include("LSF.jl")                                 #functions to apply LSF
+    include("utils.jl")                               #functions to apply LSF, vac<->air wls
 
 end # module

--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -1,5 +1,6 @@
 module Korg
-    export synthesize, constant_R_LSF, read_line_list, read_model_atmosphere
+    export synthesize, constant_R_LSF, rectify, air_to_vacuum, vacuum_to_air, read_line_list, 
+            read_model_atmosphere
 
     _data_dir = joinpath(@__DIR__, "../data") 
 
@@ -18,6 +19,6 @@ module Korg
 
     include("continuum_opacity/continuum_opacity.jl") #Define continuum opacity functions.
     include("synthesize.jl")                          #solve radiative transfer equation
-    include("utils.jl")                               #functions to apply LSF, vac<->air wls
+    include("utils.jl")                               #functions to apply LSF, vac<->air wls, etc
 
 end # module

--- a/src/LSF.jl
+++ b/src/LSF.jl
@@ -7,7 +7,7 @@ This will have weird behavior if your wavelength grid is not locally linearly-sp
 It is intended to be run on a fine wavelength grid, then downsampled to the observational (or 
 otherwise desired) grid.
 """
-function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: AbstractFloat
+function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
     #ideas - require wls to be a range object? Use erf to account for grid edges?
     convF = zeros(F, length(flux))
     for i in 1:length(wls)

--- a/src/continuum_opacity/continuum_opacity.jl
+++ b/src/continuum_opacity/continuum_opacity.jl
@@ -28,5 +28,5 @@ I adopted the formula described in section 5.12 of Kurucz (1970) and the equatio
 scattering subsection of Gray (2005); the actual coefficient value comes from the latter. It turns
 out that the coefficient in Kurucz (1970) has a typo (it's a factor of 10 too large).
 """
-electron_scattering(nₑ::F, ρ::F) where {F<:AbstractFloat} = 0.6648e-24*nₑ/ρ
+electron_scattering(nₑ::F, ρ::F) where {F<:Real} = 0.6648e-24*nₑ/ρ
 end

--- a/src/continuum_opacity/hydrogenic_bf_ff.jl
+++ b/src/continuum_opacity/hydrogenic_bf_ff.jl
@@ -10,11 +10,11 @@ Calculates the LTE number density (in cm^-3) of a hydrogenic species at a given 
 
 # Arguments
 - `n::Integer`: The quantum number of the state
-- `nsdens_div_partition::Flt`: The total (including all states) number density of the current 
+- `nsdens_div_partition`: The total (including all states) number density of the current 
 ionization species (in cm^-3) divided by the species's partition function.
-- `ion_energy::Flt`: The minimum energy (in eV) required to ionize the species (from the ground 
+- `ion_energy`: The minimum energy (in eV) required to ionize the species (from the ground 
 state). This can be estimated as Z²*ion_energy of hydrogen or Z²*Rydberg_H.
-- `T::Flt`: Temperature
+- `T`: Temperature
 
 # Note
 This assumes that all hydrogenic species have a statistical weight of gₙ = 2*n².
@@ -22,8 +22,7 @@ This assumes that all hydrogenic species have a statistical weight of gₙ = 2*n
 This was taken from equation (5.4) of Kurucz (1970) (although this comes directly from the 
 boltzmann equation).
 """
-function ndens_state_hydrogenic(n::Integer, nsdens_div_partition::Flt, T::Flt,
-                                ion_energy::Flt) where {Flt<:AbstractFloat}
+function ndens_state_hydrogenic(n::Integer, nsdens_div_partition::Real, T::Real, ion_energy::Real)
     n2 = n*n
     g_n = 2.0*n2
     energy_level = ion_energy - ion_energy/n2
@@ -46,7 +45,7 @@ const _bf_σ_coef = SA[(0.9916,  2.719e13, -2.268e30),
  
 # this is helper function is the most likely part of the calculation to change.
 # This uses double precision to be safe about the polynomial coefficients.
-function _hydrogenic_bf_cross_section(Z::Integer, n::Integer, ν::Float64, ion_freq::Float64)
+function _hydrogenic_bf_cross_section(Z::Integer, n::Integer, ν::Real, ion_freq::Real)
     # this implements equation 5.5 from Kurucz (1970)
     # - Z is the atomic number
     # - n is the energy level (remember, they start from n=1)
@@ -88,20 +87,18 @@ where α(n=n') is the absorption coefficient for the bound-free atomic absorptio
 # Arguments
 - `Z::Integer`: Z is the atomic number of the ion (1 for HI)
 - `nmin::Integer`: The lowest energy level (principle quantum number) included in the calculation
-- `nsdens_div_partition::AbstractFloat` is the number density of the current species divided by the
+- `nsdens_div_partition::Real` is the number density of the current species divided by the
    partition function.
-- `ν::Flt`: frequency in Hz
-- `ρ::Flt`: mass density in g/cm³
-- `T::Flt`: temperature in K
-- `ion_energy::AbstractFloat`: the ionization energy from the ground state (in eV).
+- `ν`: frequency in Hz
+- `ρ`: mass density in g/cm³
+- `T`: temperature in K
+- `ion_energy::Real`: the ionization energy from the ground state (in eV).
 
 # Notes
 This implements equation (5.6) from Kurucz (1970). I think ρ was simply omitted from that equation.
 """
-function _hydrogenic_bf_high_n_opacity(Z::Integer, nmin::Integer,
-                                       nsdens_div_partition::AbstractFloat,
-                                       ν::AbstractFloat, ρ::AbstractFloat, T::AbstractFloat,
-                                       ion_energy::AbstractFloat)
+function _hydrogenic_bf_high_n_opacity(Z::Integer, nmin::Integer, nsdens_div_partition::Real, 
+                                       ν::Real, ρ::Real, T::Real, ion_energy::Real)
 
     # this function corresponds to the evaluation of a integral. We subdivide the solution into two
     # parts: (i) consts and (ii) integral. The solution is the product of both parts
@@ -149,12 +146,12 @@ integral.
 
 # Arguments
 - `Z::Integer`: Z is the atomic number of the species (e.g. 1 for H I or 2 for He II)
-- `nsdens_div_partition::Flt` is the total number density of the species divided by the species's
+- `nsdens_div_partition` is the total number density of the species divided by the species's
    partition function.
-- `ν::Flt`: frequency in Hz
-- `ρ::Flt`: mass density in g/cm³
-- `T::Flt`: temperature in K
-- `ion_energy::AbstractFloat`: the ionization energy from the ground state (in eV). This can be 
+- `ν`: frequency in Hz
+- `ρ`: mass density in g/cm³
+- `T`: temperature in K
+- `ion_energy::Real`: the ionization energy from the ground state (in eV). This can be 
    estimated as Z²*Rydberg_H (Rydberg_H is the ionization energy of Hydrogen)
 - `nmax_explicit_sum::Integer`: The highest energy level whose opacity contribution is included in
    the explicit sum. The contributions from higher levels are included in the integral.
@@ -164,9 +161,9 @@ integral.
 # Notes
 This follows the approach described in section 5.1 of Kurucz (1970).
 """
-function hydrogenic_bf_opacity(Z::Integer, nsdens_div_partition::Flt, ν::Flt, ρ::Flt, T::Flt,
-                               ion_energy::Flt, nmax_explicit_sum::Integer,
-                               integrate_high_n::Bool = true) where {Flt<:AbstractFloat}
+function hydrogenic_bf_opacity(Z::Integer, nsdens_div_partition::Real, ν::Real, ρ::Real, T::Real, 
+                               ion_energy::Real, nmax_explicit_sum::Integer, 
+                               integrate_high_n::Bool=true)
     ionization_freq = _eVtoHz(ion_energy)
 
     # first, directly sum individual the opacity contributions from H I atoms at each of the lowest
@@ -221,8 +218,8 @@ computes the thermally averaged free-free gaunt factor by interpolating the tabl
 section 5.1 of Kurucz (1970). The table was derived from a figure in Karsas and Latter (1961).
 
 # Arguments
-- `log_u::F`: Equal to log₁₀(u) = log₁₀(h*ν/(k*T))
-- `log_γ2::F`: Equal to log₁₀(γ²) = log₁₀(RydbergH*Z²/(k*T))
+- `log_u`: Equal to log₁₀(u) = log₁₀(h*ν/(k*T))
+- `log_γ2`: Equal to log₁₀(γ²) = log₁₀(RydbergH*Z²/(k*T))
 
 # Note
 There is some ambiguity over whether we should replace RydbergH*Z² in the definition of γ² with the
@@ -250,11 +247,11 @@ means that `ni` should refer to:
 
 # Arguments
 - `Z::Integer`: the charge of the ion. For example, this is 1 for ionized H.
-- `ni::Flt`: the number density of the ion species in cm⁻³.
-- `ne::Flt`: the number density of free electrons.
-- `ν::Flt`: frequency in Hz
-- `ρ::Flt`: mass density in g/cm³
-- `T::Flt`: temperature in K
+- `ni`: the number density of the ion species in cm⁻³.
+- `ne`: the number density of free electrons.
+- `ν`: frequency in Hz
+- `ρ`: mass density in g/cm³
+- `T`: temperature in K
 
 # Note
 This approach was adopted from equation 5.8 from section 5.1 of Kurucz (1970). Comparison against
@@ -269,10 +266,9 @@ With this in mind, equation 5.8 of Kurucz (1970) should actually read
     ne * n(H II) * F_ν(T) * (1 - exp(-hplanck*ν/(kboltz*T))) / ρ
 where F_ν(T) = coef * Z² * g_ff / (sqrt(T) * ν³).
 """
-function hydrogenic_ff_opacity(Z::Integer, ni::Flt, ne::Flt, ν::Flt, ρ::Flt,
-                               T::Flt) where {Flt<:AbstractFloat}
+function hydrogenic_ff_opacity(Z::Integer, ni::Real, ne::Real, ν::Real, ρ::Real, T::Real)
     β = 1.0/(kboltz_eV * T)
-    Z2 = convert(Flt, Z*Z)
+    Z2 = Z*Z
 
     hν_div_kT = hplanck_eV * ν * β
     log_u = log10(hν_div_kT)

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -51,7 +51,7 @@ Compute the H⁻ bound-free cross-section, which has units of cm^2 per H⁻ part
 
 The cross-section does not include a correction for stimulated emission.
 """
-function _Hminus_bf_cross_section(ν::AbstractFloat)
+function _Hminus_bf_cross_section(ν::Real)
     λ = c_cgs*1e8/ν # in Angstroms
     # we need to somehow factor out this bounds checking
     if !(2250 <= λ <= 15000.0)
@@ -113,8 +113,8 @@ data from Wishart (1979). While Gray (2005) claims that the polynomial fits the 
 precision for 2250 Å ≤ λ ≤ 15000 Å, in practice we find that it fits the data to better than 0.25%
 precision. Wishart (1979) expects the tabulated data to have better than 1% percent accuracy.
 """
-function Hminus_bf(nH_I_div_partition::Flt, ne::Flt, ν::Flt, ρ::Flt, T::Flt,
-                   ion_energy_H⁻::Flt = 0.7552) where {Flt<:AbstractFloat}
+function Hminus_bf(nH_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real, 
+                   ion_energy_H⁻::Real = 0.7552)
     αbf_H⁻ = _Hminus_bf_cross_section(ν) # does not include contributions from stimulated emission
     stimulated_emission_correction = (1 - exp(-hplanck_cgs*ν/(kboltz_cgs*T)))
     n_H⁻ = _ndens_Hminus(nH_I_div_partition, ne, T, _H⁻_ion_energy)
@@ -162,8 +162,7 @@ n(H I, n = 1) over the temperature range where the polynomial is valid.
 We also considered the polynomial fit in Section 5.3 from Kurucz (1970). Unfortunately, it seems
 wrong (it gives lots of negative numbers).
 """
-function Hminus_ff(nH_I_div_partition::Flt, ne::Flt, ν::Flt, ρ::Flt,
-                   T::Flt) where {Flt<:AbstractFloat}
+function Hminus_ff(nH_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real)
     λ = c_cgs*1e8/ν # in Angstroms
     # we need to somehow factor out this bounds checking
     if !(2604 <= λ <= 113918.0)
@@ -207,12 +206,12 @@ This uses polynomial fits from Gray (2005) that were derived from data tabulated
 [Bates (1952)](https://ui.adsabs.harvard.edu/abs/1952MNRAS.112...40B/abstract).
 
 # Arguments
-- `nH_I_div_partition::Float64`: the total number density of H I divided by its partition 
+- `nH_I_div_partition`: the total number density of H I divided by its partition 
    function.
-- `nH_II::Float64`: the number density of H II (not of H₂⁺).
-- `ν::Float64`: frequency in Hz
-- `ρ::Float64`: mass density in g/cm³
-- `T::Float64`: temperature in K
+- `nH_II`: the number density of H II (not of H₂⁺).
+- `ν`: frequency in Hz
+- `ρ`: mass density in g/cm³
+- `T`: temperature in K
 
 # Notes
 This follows equation 8.15 of Gray (2005), which involves 2 polynomials that were fit to data
@@ -247,8 +246,7 @@ times larger than the max λ the polynomials are fit against). He suggests that 
 probably correct "to well within one part in ten even at the lower temperatures and [lower
 wavelengths]."
 """
-function H2plus_bf_and_ff(nH_I_div_partition::Float64, nH_II::Float64, ν::Float64, ρ::Float64,
-                          T::Float64)
+function H2plus_bf_and_ff(nH_I_div_partition::Real, nH_II::Real, ν::Real, ρ::Real, T::Real)
     λ = c_cgs*1e8/ν # in ångstroms
     if !(3846.15 <= λ <= 25000.0) # the lower limit is set to include 1.e5/26 Å
         throw(DomainError(λ, "The wavelength must lie in the interval [3847 Å, 25000 Å]"))

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -213,6 +213,9 @@ This uses polynomial fits from Gray (2005) that were derived from data tabulated
 - `ρ`: mass density in g/cm³
 - `T`: temperature in K
 
+While the formal type signature requires that these be `Real`, `Float32`s (or `Float32`-derived 
+types) may introduce numerical instability.
+
 # Notes
 This follows equation 8.15 of Gray (2005), which involves 2 polynomials that were fit to data
 provided in [Bates (1952)](https://ui.adsabs.harvard.edu/abs/1952MNRAS.112...40B/abstract).

--- a/src/continuum_opacity/opacity_He.jl
+++ b/src/continuum_opacity/opacity_He.jl
@@ -19,7 +19,7 @@ He_II_ff(nHe_III, ne, ν, ρ, T) = hydrogenic_ff_opacity(2, nHe_III, ne, ν, ρ,
 
 # Compute the number density of atoms in different He I states
 # taken from section 5.5 of Kurucz (1970)
-function ndens_state_He_I(n::Integer, nsdens_div_partition::Flt, T::Flt) where {Flt<:AbstractFloat}
+function ndens_state_He_I(n::Integer, nsdens_div_partition::Real, T::Real)
     g_n, energy_level = if n == 1
         (1.0, 0.0)
     elseif n == 2
@@ -84,8 +84,7 @@ approximations for 5.06e3 Å ≤ λ ≤ 1e4 Å "are expected to be well below 10
 
 An alternative approach using a fit to older data is provided in section 5.7 of Kurucz (1970).
 """
-function Heminus_ff(nHe_I_div_partition::Flt, ne::Flt, ν::Flt, ρ::Flt,
-                    T::Flt) where {Flt<:AbstractFloat}
+function Heminus_ff(nHe_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real)
 
     λ = c_cgs * 1.0e8 / ν # Å
     if !(5063.0 <= λ <= 151878.0)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -1,0 +1,24 @@
+using Random
+using Optim
+
+function best_fit_params(atm, linelist, wls, f_obs; ivar=ones(length(f_obs)),
+                         free_parameters=["metallicity", "vmic"], fixed_values::Dict=Dict(),
+                         initial_values::Dict=Dict(), wl_deflation_factor=0.01)
+
+    function chi2(params, wl_mask)
+        f_synth = synthesize(atm, linelist, wls[wl_mask]; metallicity=params[1],
+                             abundances=Dict(["Ca"=>params[2]]), verbose=false).flux
+        f_synth = Korg.constant_R_LSF(f_synth, wls[wl_mask], 11500.0)
+        sum((f_obs[wl_mask] .- f_synth).^2 .* ivar[wl_mask])
+    end
+    
+    mask = rand(length(wls)) .< wl_deflation_factor
+    
+    result = optimize(p->chi2(p, mask), [0.0, 0.0], NewtonTrustRegion(),
+        Optim.Options(show_trace=true, extended_trace=true, x_tol=1e-1);
+        autodiff=:forward)
+    
+    optimize(p->chi2(p, ones(Bool, length(wls))), result.minimizer, NewtonTrustRegion(),
+        Optim.Options(show_trace=true, extended_trace=true, x_tol=1e-3);
+        autodiff=:forward)
+end

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -49,6 +49,13 @@ function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition
                   (n_densities["H_I"] + 0.42n_densities["He_I"])*scaled_vdW(line.vdW, mass, temp))
         end
 
+        #hack in Hα resonant broadening
+        if line.species == "H_I" && (6e-5 < line.wl < 7e-5)
+            Γauto = scaled_vdW((1180*bohr_radius_cgs^2, 0.677), mass, temp) * n_densities["H_I"] 
+            Γstark = nₑ*scaled_stark(line.gamma_stark, temp)
+            Γ += Γauto - Γstark
+        end
+
         #doing this involves an implicit aproximation that λ(ν) is linear over the line window
         Δλ_L = Γ * line.wl^2 / c_cgs
 

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -47,7 +47,7 @@ function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition
         #get all damping params from line list.  There may be better sources for this.
         Γ = line.gamma_rad 
         if !ismolecule(line.species) 
-            Γ += (nₑ*scaled_stark(line.gamma_stark, temp) + 
+            Γ += (nₑ*scaled_stark(line.gamma_stark, temp) +
                   (n_densities["H_I"] + 0.42n_densities["He_I"])*scaled_vdW(line.vdW, mass, temp))
         end
 
@@ -85,7 +85,6 @@ end
 
 "the stark broadening gamma scaled acording to its temperature dependence"
 scaled_stark(γstark, T; T₀=10_000) = γstark * (T/T₀)^(1/6)
-
              
 """
 the vdW broadening gamma scaled acording to its temperature dependence, using either simple scaling 

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -24,14 +24,15 @@ otherwise specified
 """
 function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition_fns::Dict, ξ 
                          ; α_cntm=nothing, cutoff_threshold=1e-3, window_size=20.0*1e-8)
+    if length(linelist) == 0
+        return zeros(length(λs))
+    end
+
     #type shenanigans to allow autodiff to do its thing
     α_type = typeof(promote(linelist[1].wl, λs[1], temp, nₑ, n_densities["H_I"], ξ, cutoff_threshold
                            )[1])
     α_lines = zeros(α_type, length(λs))
 
-    if length(linelist) == 0
-        return α_lines
-    end
 
     #lb and ub are the indices to the upper and lower wavelengths in the "window", i.e. the shortest
     #and longest wavelengths which feel the effect of each line 

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -49,13 +49,6 @@ function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition
                   (n_densities["H_I"] + 0.42n_densities["He_I"])*scaled_vdW(line.vdW, mass, temp))
         end
 
-        #hack in Hα resonant broadening
-        if line.species == "H_I" && (6e-5 < line.wl < 7e-5)
-            Γauto = scaled_vdW((1180*bohr_radius_cgs^2, 0.677), mass, temp) * n_densities["H_I"] 
-            Γstark = nₑ*scaled_stark(line.gamma_stark, temp)
-            Γ += Γauto - Γstark
-        end
-
         #doing this involves an implicit aproximation that λ(ν) is linear over the line window
         Δλ_L = Γ * line.wl^2 / c_cgs
 

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -132,7 +132,7 @@ end
 The cross-section (divided by gf) at wavelength `wl` in Ångstroms of a transition for which the product of the
 degeneracy and oscillator strength is `10^log_gf`.
 """
-function sigma_line(λ) where F <: Real
+function sigma_line(λ::Real)
     #work in cgs
     e  = electron_charge_cgs
     mₑ = electron_mass_cgs

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -24,14 +24,15 @@ otherwise specified
 """
 function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition_fns::Dict, ξ 
                          ; α_cntm=nothing, cutoff_threshold=1e-3, window_size=20.0*1e-8)
-    if length(linelist) == 0
-        return 0
-    end
-
     #type shenanigans to allow autodiff to do its thing
     α_type = typeof(promote(linelist[1].wl, λs[1], temp, nₑ, n_densities["H_I"], ξ, cutoff_threshold
                            )[1])
     α_lines = zeros(α_type, length(λs))
+
+    if length(linelist) == 0
+        return α_lines
+    end
+
     #lb and ub are the indices to the upper and lower wavelengths in the "window", i.e. the shortest
     #and longest wavelengths which feel the effect of each line 
     lb = 1

--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -66,7 +66,8 @@ function line_absorption(linelist, λs, temp, nₑ, n_densities::Dict, partition
 
         if !isnothing(α_cntm)
             α_crit = α_cntm(line.wl) * cutoff_threshold
-            window_size = max(4Δλ_D, sqrt(line_amplitude * Δλ_L / α_crit))
+            Δλ_crit = sqrt(line_amplitude * Δλ_L / α_crit) #where α from lorentz component == α_crit
+            window_size = max(4Δλ_D, Δλ_crit)
         end
         lb, ub = move_bounds(λs, lb, ub, line.wl, window_size)
         if lb==ub

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -305,7 +305,7 @@ function parse_vald_linelist(f)
         if shortformat
             #extract all
             if firstline == 3
-                new_lines_imputing_zeros(
+                new_line_imputing_zeros(
                      wl_transform(parse(Float64, toks[2])*1e-8),
                      parse(Float64, toks[4]),
                      _vald_to_korg_species_code(toks[1]),

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -161,7 +161,7 @@ function approximate_gammas(wl, species, E_lower; ionization_energies=ionization
                 " exceeds the ionization energy (E_upper) > $(χ)). Using null broadening params.")
         γvdW = 0.0
     else
-        #From R J Rutten's course notes. An equivalent form can be found in Gray 2005.
+        #(log) γ_vdW From R J Rutten's course notes. An equivalent form can be found in Gray 2005.
         γvdW = 6.33 + 0.4log10(Δrbar2) + 0.3log10(10_000) + log10(k)
     end
 

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -303,14 +303,30 @@ function parse_vald_linelist(f)
     map(lines) do line
         toks = split(line, ',')
         if shortformat
-            new_line_imputing_zeros(
-                parse(Float64, toks[2])*1e-8,
-                parse(Float64, toks[5]),
-                _vald_to_korg_species_code(toks[1]),
-                parse(Float64, toks[3]),
-                expOrZero(parse(Float64, toks[6])),
-                expOrZero(parse(Float64, toks[7])),
-                parse(Float64, toks[8]))
+            #extract all
+            if firstline == 3
+                new_lines_imputing_zeros(
+                     wl_transform(parse(Float64, toks[2])*1e-8),
+                     parse(Float64, toks[4]),
+                     _vald_to_korg_species_code(toks[1]),
+                     E_transform(parse(Float64, toks[3])),
+                     expOrZero(parse(Float64, toks[5])),
+                     expOrZero(parse(Float64, toks[6])),
+                     parse(Float64, toks[7]))
+            #extract stellar
+            elseif firstline == 4
+                new_line_imputing_zeros(
+                     wl_transform(parse(Float64, toks[2])*1e-8),
+                     parse(Float64, toks[5]),
+                     _vald_to_korg_species_code(toks[1]),
+                     E_transform(parse(Float64, toks[3])),
+                     expOrZero(parse(Float64, toks[6])),
+                     expOrZero(parse(Float64, toks[7])),
+                     parse(Float64, toks[8]))
+            else
+                throw(ArgumentError("Can't determine if this is an \"extract all\" or \"extract " *
+                                    "stellar\" format linelist"))
+            end
         else
             new_line_imputing_zeros(
                 parse(Float64, toks[2])*1e-8,

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -83,7 +83,7 @@ struct Line{F}
     interpret it as log10(Γ) per particle.  Otherwise, interpret it as packed ABO parameters.
     """
     function Line(wl::F, log_gf::F, species::String, E_lower::F, gamma_rad::F, gamma_stark::F,
-                  vdW::F) where F <: AbstractFloat
+                  vdW::F) where F <: Real
         new{F}(wl, log_gf, species, E_lower, gamma_rad, gamma_stark, 
                if vdW > 0
                    floor(vdW) * bohr_radius_cgs * bohr_radius_cgs, vdW - floor(vdW)
@@ -96,7 +96,7 @@ end
 """
 Construct a `Line` without explicit broadening parameters.
 """
-function Line(wl::F, log_gf::F, species::String, E_lower::F) where F <: AbstractFloat
+function Line(wl::F, log_gf::F, species::String, E_lower::F) where F <: Real
     Line(wl, log_gf, species, E_lower, approximate_radiative_gamma(wl, log_gf),
          approximate_gammas(wl, species, E_lower)...)
 end

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -348,8 +348,6 @@ function parse_moog_linelist(f)
     #moog format requires blank first line
     linelist = map(lines[2:end]) do line
         toks = split(line)
-        wl =
-        parse(Float64, toks[4])
         Line(parse(Float64, toks[1]) * 1e-8, #convert Å to cm
              parse(Float64, toks[4]),
              parse_species_code(toks[2]),

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -124,7 +124,7 @@ A simplified form of the Unsoeld (1995) approximation for van der Waals and Star
 Returns log10(γ_vdW).
 
 In the calculation of n*², uses the approximation that
-\\overbar{r}^2 = 5/2 {n^*}^4 / Z^2
+\\overbar{r^2} = 5/2 {n^*}^4 / Z^2
 which neglects the dependence on the angular momentum quantum number, l, in the the form given by
 Warner 1967.
 

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -260,6 +260,17 @@ function parse_vald_linelist(f)
         line[1] == '\''
     end
 
+    #air or vacuum wls?
+    wl_header = split(lines[firstline-1])[3]
+    if contains(wl_header, "air")
+        wl_transform = air_to_vacuum
+    elseif contains(wl_header, "vac")
+        wl_transform = identity
+    else
+        throw(ArgumentError(
+            "Can't parse line list.  I don't understant this wavelength column name: " * wl_header))
+    end
+
     #vald short or long format?
     if isuppercase(lines[firstline][2]) && isuppercase(lines[firstline+1][2])
         Δ = 1 # short format

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -87,6 +87,8 @@ struct Line{F}
         new{F}(wl, log_gf, species, E_lower, gamma_rad, gamma_stark, 
                if vdW > 0
                    floor(vdW) * bohr_radius_cgs * bohr_radius_cgs, vdW - floor(vdW)
+               elseif vdW == 0
+                   0.0
                else 
                    10^vdW
                end

--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -50,7 +50,7 @@ function saha_ion_weights(T, nₑ, atom::String, ionization_energies::Dict, part
     wII, wIII
 end
 "convieience method for easier testing"
-function saha_ion_weights(T, nₑ, χs::Vector{<:AbstractFloat}, Us::Vector{Function})
+function saha_ion_weights(T, nₑ, χs::Vector{<:Real}, Us::Vector{Function})
     ionization_energies = Dict(["X" => χs])
     partition_funcs = Dict(["X_I" => Us[1], "X_II" => Us[2], "X_III" => Us[3]])
     saha_ion_weights(T, nₑ, "X", ionization_energies, partition_funcs)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -152,7 +152,7 @@ function total_continuum_opacity(νs::Vector{F}, T::F, nₑ::F, ρ::F, number_de
     nH_I_div_U = nH_I / partition_funcs["H_I"](T)
     κ += ContinuumOpacity.H_I_bf.(nH_I_div_U, νs, ρ, T) 
     κ += ContinuumOpacity.H_I_ff.(number_densities["H_II"], nₑ, νs, ρ, T)
-    κ += ContinuumOpacity.Hminus_bf.(nH_I_div_U, nₑ, νs, ρ, T)
+    #κ += ContinuumOpacity.Hminus_bf.(nH_I_div_U, nₑ, νs, ρ, T)
     κ += ContinuumOpacity.Hminus_ff.(nH_I_div_U, nₑ, νs, ρ, T)
     #κ += ContinuumOpacity.H2plus_bf_and_ff.(nH_I_div_U, number_densities["H_II"], νs, ρ, T)
     

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -1,4 +1,3 @@
-using SpecialFunctions: expint
 import Interpolations #for Interpolations.line
 using Interpolations: LinearInterpolation
 import ..ContinuumOpacity
@@ -30,7 +29,7 @@ Uses solar abundances scaled by `metallicity` and for those not provided.
 function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, abundances=Dict(), 
                     line_window::Real=10.0, cntm_step::Real=1.0, 
                     ionization_energies=ionization_energies, partition_funcs=partition_funcs,
-                    equilibrium_constants=equilibrium_constants)
+                    equilibrium_constants=equilibrium_constants, verbose=true)
     #work in cm
     λs = λs * 1e-8
     cntm_step *= 1e-8
@@ -46,9 +45,11 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
     #remove lines outside of wavelength range. Note that this is not passed to line_absorption 
     #because that will hopefully be set dynamically soon
     nlines = length(linelist)
-    linelist = filter(l-> λs[1] - line_window <= l.wl <= λs[end] + line_window, linelist)
-    if length(linelist) != nlines
-        @info "omitting $(nlines - length(linelist)) lines which fall outside the wavelength range"
+
+    linelist = filter(l-> λs[1] - line_window*1e-8 <= l.wl <= λs[end] + line_window*1e-8, linelist)
+    if verbose && length(linelist) != nlines
+        println("omitting $(nlines - length(linelist))" * 
+                " lines which fall outside the wavelength range")
     end
 
     #impotent = setdiff(Set(keys(abundances)), elements)
@@ -90,14 +91,13 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
 
     source_fn = blackbody.((l->l.temp).(atm), λs')
 
-    #This isn't the standard solution to the transfer equation.
     #The exponential integral function, expint, captures the integral over the disk of the star to 
     #get the emergent astrophysical flux. I was made aware of this form of the solution, by
     #Edmonds+ 1969 (https://ui.adsabs.harvard.edu/abs/1969JQSRT...9.1427E/abstract).
     #You can verify it by substituting the variable of integration in the exponential integal, t,
     #with mu=1/t.
     flux = map(zip(eachcol(τ), eachcol(source_fn))) do (τ_λ, S_λ)
-        trapezoid_rule(τ_λ, S_λ .* expint.(2, τ_λ))
+        trapezoid_rule(τ_λ, S_λ .* exponential_integral_2.(τ_λ))
     end
 
     #return the solution, along with other quantities across wavelength and atmospheric layer.
@@ -205,3 +205,76 @@ function trapezoid_rule(xs, fs)
     weights = [0 ; Δs] + [Δs ; 0]
     sum(0.5 * weights .* fs)
 end
+
+"""
+Approximate second order exponential integral, E_2(x).  This stiches together several series 
+expansions to get an approximation which is accurate within 1% for all `x`.
+"""
+function exponential_integral_2(x) 
+    if x < 1.1
+        _expint_small(x)
+    elseif x < 2.5
+        _expint_2(x)
+    elseif x < 3.5
+        _expint_3(x)
+    elseif x < 4.5
+        _expint_4(x)
+    elseif x < 5.5
+        _expint_5(x)
+    elseif x < 6.5
+        _expint_6(x)
+    elseif x < 7.5
+        _expint_7(x)
+    elseif x < 9
+        _expint_8(x)
+    else
+        _expint_large(x)
+    end
+end
+
+function _expint_small(x) 
+    #euler mascheroni constant
+    ℇ = 0.57721566490153286060651209008240243104215933593992
+    1 + ((log(x) + ℇ - 1) + (-0.5 + (0.08333333333333333 + (-0.013888888888888888 + 
+                                                            0.0020833333333333333*x)*x)*x)*x)*x
+end
+function _expint_large(x)
+    invx = 1/x
+    exp(-x) * (1 + (-2 + (6 + (-24 + 120*invx)*invx)*invx)*invx)*invx
+end
+function _expint_2(x)
+    x -= 2
+    0.037534261820486914 + (-0.04890051070806112 + (0.033833820809153176 + (-0.016916910404576574 + 
+                                          (0.007048712668573576 -0.0026785108140579598*x)*x)*x)*x)*x
+end
+function _expint_3(x)
+    x -= 3
+    0.010641925085272673   + (-0.013048381094197039   + (0.008297844727977323   + 
+            (-0.003687930990212144   + (0.0013061422257001345  - 0.0003995258572729822*x)*x)*x)*x)*x
+end
+function _expint_4(x)
+    x -= 4
+    0.0031982292493385146  + (-0.0037793524098489054  + (0.0022894548610917728  + 
+            (-0.0009539395254549051  + (0.00031003034577284415 - 8.466213288412284e-5*x )*x)*x)*x)*x
+end
+function _expint_5(x)
+    x -= 5
+    0.000996469042708825   + (-0.0011482955912753257  + (0.0006737946999085467  +
+            (-0.00026951787996341863 + (8.310134632205409e-5   - 2.1202073223788938e-5*x)*x)*x)*x)*x
+end
+function _expint_6(x)
+    x -= 6
+    0.0003182574636904001  + (-0.0003600824521626587  + (0.00020656268138886323 + 
+            (-8.032993165122457e-5   + (2.390771775334065e-5   - 5.8334831318151185e-6*x)*x)*x)*x)*x
+end
+function _expint_7(x)
+    x -= 7
+    0.00010350984428214624 + (-0.00011548173161033826 + (6.513442611103688e-5   + 
+            (-2.4813114708966427e-5  + (7.200234178941151e-6   - 1.7027366981408086e-6*x)*x)*x)*x)*x
+end
+function _expint_8(x)
+    x -= 8
+    3.413764515111217e-5   + (-3.76656228439249e-5    + (2.096641424390699e-5   + 
+            (-7.862405341465122e-6   + (2.2386015208338193e-6  - 5.173353514609864e-7*x )*x)*x)*x)*x
+end
+

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -63,7 +63,6 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
     #the absorption coefficient, α, for each wavelength and atmospheric layer
     α_type = typeof(promote(atm[1].temp, length(linelist) > 0 ? linelist[1].wl : 1.0, λs[1], 
                             metallicity, vmic, abundances["H"])[1])
-    println(α_type)
     α = Matrix{α_type}(undef, length(atm), length(λs))
     for (i, layer) in enumerate(atm)
         number_densities = molecular_equilibrium(MEQs, layer.temp, layer.number_density,

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -1,7 +1,6 @@
 import Interpolations #for Interpolations.line
 using Interpolations: LinearInterpolation
 import ..ContinuumOpacity
-import ForwardDiff
 
 """
     synthesize(atm, linelist, λs, [metallicity, [alpha]]; abundances=Dict())

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -33,8 +33,8 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
     #work in cm
     λs = λs * 1e-8
     cntm_step *= 1e-8
-    line_window *= 1e-8
-    cntmλs = (λs[1] - line_window - cntm_step) : cntm_step : (λs[end] + line_window + cntm_step)
+    line_buffer *= 1e-8
+    cntmλs = (λs[1] - line_buffer - cntm_step) : cntm_step : (λs[end] + line_buffer + cntm_step)
 
     #sort the lines if necessary and check that λs is sorted
     issorted(linelist; by=l->l.wl) || sort!(linelist, by=l->l.wl)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -42,7 +42,6 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
         throw(ArgumentError("λs must be sorted"))
     end
 
-    nlines = length(linelist)
     linelist = filter(l-> λs[1] - line_buffer*1e-8 <= l.wl <= λs[end] + line_buffer*1e-8, linelist)
 
     #impotent = setdiff(Set(keys(abundances)), elements)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -12,8 +12,9 @@ optional arguments:
 - `metallicity`, i.e. [metals/H] is log_10 solar relative
 - `vmic` (default: 0) is the microturbulent velocity, ξ, in km/s.
 - `abundances` are A(X) format, i.e. A(x) = log_10(n_X/n_H), where n_X is the number density of X.
-- `line_window` (default: 10): the farthest any line can be from the provide wavelenth range range
-   before it is discarded (in Å).
+- `line_buffer` (default: 10): the farthest (in Å) any line can be from the provide wavelenth range 
+   before it is discarded.  If the edge of your window is near a strong line, you may have to turn 
+   this up.
 - `cntm_step`: the wavelength resolution with which continuum opacities are calculated.
 - `ionization_energies`, a Dict containing the first three ionization energies of each element, 
    defaults to `Korg.ionization_energies`.
@@ -26,9 +27,9 @@ optional arguments:
 Uses solar abundances scaled by `metallicity` and for those not provided.
 """
 function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, abundances=Dict(), 
-                    line_window::Real=10.0, cntm_step::Real=1.0, 
+                    line_buffer::Real=10.0, cntm_step::Real=1.0, 
                     ionization_energies=ionization_energies, partition_funcs=partition_funcs,
-                    equilibrium_constants=equilibrium_constants, verbose=true)
+                    equilibrium_constants=equilibrium_constants)
     #work in cm
     λs = λs * 1e-8
     cntm_step *= 1e-8
@@ -41,15 +42,8 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
         throw(ArgumentError("λs must be sorted"))
     end
 
-    #remove lines outside of wavelength range. Note that this is not passed to line_absorption 
-    #because that will hopefully be set dynamically soon
     nlines = length(linelist)
-
-    linelist = filter(l-> λs[1] - line_window*1e-8 <= l.wl <= λs[end] + line_window*1e-8, linelist)
-    if verbose && length(linelist) != nlines
-        println("omitting $(nlines - length(linelist))" * 
-                " lines which fall outside the wavelength range")
-    end
+    linelist = filter(l-> λs[1] - line_buffer*1e-8 <= l.wl <= λs[end] + line_buffer*1e-8, linelist)
 
     #impotent = setdiff(Set(keys(abundances)), elements)
     #if length(impotent) > 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,3 +20,15 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
     end
     convF
 end
+
+function air_to_vacuum(λ)
+    s = 1e4/λ
+    n = 1 + 0.00008336624212083 + 0.02408926869968 / (130.1065924522 - s^2) + 0.0001599740894897 / (38.92568793293 - s^2)
+    λ * n
+end
+
+function vacuum_to_air(λ)
+    s = 1e4/λ
+    n = 1 + 0.0000834254 + 0.02406147 / (130 - s^2) + 0.00015998 / (38.9 - s^2)
+    λ / n
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,16 @@
+using Statistics: quantile
+
 normal_pdf(Δ, σ) = exp(-0.5*Δ^2 / σ^2) / √(2π) / σ
 
 """
-Applies a gaussian line spread function with constant spectral resolution, R = λ/Δλ.
+    constant_R_LSF(flux, wls, R)
+
+Applies a gaussian line spread function the the spectrum with flux vector `flux` and wavelength
+vector `wls` with constant spectral resolution, R = λ/Δλ.
 
 This will have weird behavior if your wavelength grid is not locally linearly-spaced.
-It is intended to be run on a fine wavelength grid, then downsampled to the observational (or 
-otherwise desired) grid.
+It is intended to be run on a fine wavelength grid (``\\Delta\\lambda \\lesssim 0.05 \\AA``), then 
+downsampled to the observational (or otherwise desired) grid.
 """
 function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
     #ideas - require wls to be a range object? Use erf to account for grid edges?
@@ -21,12 +26,37 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
     convF
 end
 
+"""
+Rectify the spectrum with flux vector `flux` and wavelengths `wls` by dividing out a moving 
+`q`-quantile with `bandwidth`.
+"""
+function rectify(flux::AbstractVector{F}, wls; bandwidth=50, q=0.95) where F <: Real
+    lb = 1
+    ub = 1
+    moving_mean = map(wls) do λ
+        #move_bounds is defined in line_opacity.jl
+        lb, ub = move_bounds(wls, lb, ub, λ, bandwidth)
+        quantile(flux[lb:ub], q)
+    end
+    flux ./ moving_mean
+end
+
+"""
+    air_to_vacuum(λ)
+
+convert λ from an air wavelength to a vacuum wavelength
+"""
 function air_to_vacuum(λ)
     s = 1e4/λ
     n = 1 + 0.00008336624212083 + 0.02408926869968 / (130.1065924522 - s^2) + 0.0001599740894897 / (38.92568793293 - s^2)
     λ * n
 end
 
+"""
+    vacuum_to_air(λ)
+
+convert λ from a vacuum wavelength to an air wavelength
+"""
 function vacuum_to_air(λ)
     s = 1e4/λ
     n = 1 + 0.0000834254 + 0.02406147 / (130 - s^2) + 0.00015998 / (38.9 - s^2)

--- a/test/opacity_comparison_funcs.jl
+++ b/test/opacity_comparison_funcs.jl
@@ -92,8 +92,7 @@ end
 # This is mostly used for comparisons against panels of figure 8.5 from Gray (2005). For most
 # curves, we can simply assert that there is a fixed ionization fraction because we divide out the
 # dependence on all of these terms during the calculation
-function _semi_realisitic_dens(ne::Flt, fion::Flt = 0.02,
-                               HydrogenMassFrac::Flt = 0.76) where {Flt<:AbstractFloat}
+function _semi_realisitic_dens(ne::F, fion::F= 0.02, HydrogenMassFrac::F= 0.76) where F <: Real
     # In the interest of semi-realistic numbers, Let's assume all free electrons come from Hydrogen
     nH_I = ne/fion
     nH = ne + nH_I
@@ -252,7 +251,7 @@ struct Bounds
     end
 end
 
-function inbounds(bounds::Bounds, vals::Array{T}) where {T<:AbstractFloat}
+function inbounds(bounds::Bounds, vals::Array{F}) where F <: Real
     map(vals) do val
         ((isnothing(bounds.lower) || bounds.lower <= val) &&
          (isnothing(bounds.upper) || bounds.upper >= val))


### PR DESCRIPTION
This makes types generic enough to support autodiff.  Unfortunately, it is also necessary to define a method of `floatmax` which is defined on the relevant `ForwardDiff.Dual` subtype, e.g.
```julia
Base.floatmax(::ForwardDiff.Dual{ForwardDiff.Tag{typeof(syn), Float64}, Float64, 2}) = floatmax(1.0)
```
where `syn` is the function being differentiated, e.g. the spectrum as a function of Teff and vmic:
```julia
syn(params) = synthesize(atm, linelist, wls; metallicity=params[1], vmic=params[2]).flux
```

I will make sure this is documented at some point, and will take care of it myself in the Korg parameter estimation routines.

BTW, calculating the Jacobian in this example takes the same amount of time as synthesizing the spectrum.  Not bad!

P.S. this is branched off #32.  I will fix the diff before review.