### PR TITLE
add missing factor of 2 to astrophysical flux integral

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -89,7 +89,7 @@ function synthesize(atm, linelist, λs; metallicity::Real=0.0, vmic::Real=1.0, a
     #You can verify it by substituting the variable of integration in the exponential integal, t,
     #with mu=1/t.
     flux = map(zip(eachcol(τ), eachcol(source_fn))) do (τ_λ, S_λ)
-        trapezoid_rule(τ_λ, S_λ .* exponential_integral_2.(τ_λ))
+        2.0*trapezoid_rule(τ_λ, S_λ .* exponential_integral_2.(τ_λ))
     end
 
     #return the solution, along with other quantities across wavelength and atmospheric layer.


### PR DESCRIPTION
This add a missing factor of 2 to the final flux integral.  After doing this, our continuum in the optical closely matches MOOG's
![image](https://user-images.githubusercontent.com/711963/123699061-d3e39480-d82c-11eb-8e9e-c27cc99fa64a.png)

In the IR, our continuum is about 10% higher that MOOG's, indicating that our opacities are too low. 
![image](https://user-images.githubusercontent.com/711963/123699140-e9f15500-d82c-11eb-9e14-10adff52e540.png)
