### PR TITLE
Updated H⁻ bf opacity calculation

### DIFF
--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -77,8 +77,8 @@ function _Hminus_bf_cross_section(λ, ion_energy_H⁻)
     Å_per_eV = 1e8 * (hplanck_eV * c_cgs)
     max_λ_ionize = Å_per_eV/ion_energy_H⁻
 
-    last_table_λ = _Hminus_bf_table[size(_Hminus_bf_table, 1), 1]
-    last_table_cross_section = _Hminus_bf_table[size(_Hminus_bf_table, 1), 2]
+    last_table_λ = _Hminus_bf_table[end, 1]
+    last_table_cross_section = _Hminus_bf_table[end, 2]
 
     @assert max_λ_ionize > last_table_λ
 
@@ -115,7 +115,7 @@ Compute the H⁻ bound-free opacity κ
 This function assumes that n(H⁻) ≪ n(H I) + n(H II). The number density of n(H⁻) should not be
 pre-computed (instead it's computed internally by this function).
 
-This function is adapted from equation 8.12 from Grey (2005) This equation gives the absorption
+This function is adapted from equation 8.12 from Grey (2005). This equation gives the absorption
 coefficient per H I atom (uncorrected by stimulated emission) is given by:
 
     ``8.316e-10 \\alpha_{bf}(H^-) P_e \\theta^{2.5} * 10^{{\rm ion_energy_H}^- \\theta} U(H⁻,T)/ U(H I,T)``
@@ -144,10 +144,10 @@ suggests that this data has better than 3% accuracy.
 function Hminus_bf(nH_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real, 
                    ion_energy_H⁻::Real = _H⁻_ion_energy)
     λ = c_cgs*1e8/ν # in ångstroms
-    tmp = _Hminus_bf_cross_section(λ, ion_energy_H⁻) # in units of megabarn
+    cross_section = _Hminus_bf_cross_section(λ, ion_energy_H⁻) # in units of megabarn
     # convert from megabarn to cm² and include contributions from stimulated emission  1e-18
-    αbf_H⁻ = (1 - exp(-hplanck_cgs*ν/(kboltz_cgs*T))) * tmp * 1e-18
-    _ndens_Hminus(nH_I_div_partition, ne, T, _H⁻_ion_energy) * αbf_H⁻ / ρ
+    cross_section *= (1 - exp(-hplanck_cgs*ν/(kboltz_cgs*T))) * 1e-18
+    _ndens_Hminus(nH_I_div_partition, ne, T, _H⁻_ion_energy) * cross_section / ρ
 end
 
 

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -1,5 +1,8 @@
 # we are missing Rayleigh Scattering
 
+using Interpolations: LinearInterpolation, Throw
+using StaticArrays: SA
+
 using ..ContinuumOpacity: hydrogenic_bf_opacity, hydrogenic_ff_opacity, ionization_energies
 
 const _H_I_ion_energy = ionization_energies["H"][1] # not sure if this is a good idea
@@ -13,9 +16,6 @@ H_I_bf(nH_I_div_partition, ν, ρ, T, ion_energy = _H_I_ion_energy,
 # H I free-free actually refers to the reaction: photon + e⁻ + H II -> e⁻ + H II.
 H_I_ff(nH_II, ne, ν, ρ, T) = hydrogenic_ff_opacity(1, nH_II, ne, ν, ρ, T)
 
-# compute the number density of H⁻ (implements eqn 5.10 of Kurucz 1970). This formula comes from
-# inverting the saha equation, where n(H⁻) is n₀ and n(H I) is n₁. Note that U₀ = 1 at all
-# temperatures.
 """
     _ndens_Hminus(nH_I_div_partition, ne, T, ion_energy = _H⁻_ion_energy)
 
@@ -44,30 +44,34 @@ function _ndens_Hminus(nH_I_div_partition, ne, T, ion_energy = _H⁻_ion_energy)
 end
 
 
+const _Hminus_bf_table = SA[1250.0 5.431;   1500.0 6.512;   1750.0 7.918;   2000.0 9.453;
+                            2250.0 11.08;   2500.0 12.75;   2750.0 14.46;   3000.0 16.19;
+                            3250.0 17.92;   3500.0 19.65;   3750.0 21.35;   4000.0 23.02;
+                            4250.0 24.65;   4500.0 26.24;   4750.0 27.77;   5000.0 29.23;
+                            5250.0 30.62;   5500.0 31.94;   5750.0 33.17;   6000.0 34.32;
+                            6250.0 35.37;   6500.0 36.32;   6750.0 37.17;   7000.0 37.91;
+                            7250.0 38.54;   7500.0 39.07;   7750.0 39.48;   8000.0 39.77;
+                            8250.0 39.95;   8500.0 40.01;   8750.0 39.95;   9000.0 39.77;
+                            9250.0 39.48;   9500.0 39.06;   9750.0 38.53;   10000.0 37.89;
+                            10250.0 37.13;  10500.0 36.25;  10750.0 35.28;  11000.0 34.19;
+                            11250.0 33.01;  11500.0 31.72;  11750.0 30.34;  12000.0 28.87;
+                            12250.0 27.33;  12500.0 25.71;  12750.0 24.02;  13000.0 22.26;
+                            13250.0 20.46;  13500.0 18.62;  13750.0 16.74;  14000.0 14.85;
+                            14250.0 12.95;  14500.0 11.07;  14750.0 9.211;  15000.0 7.407;
+                            15250.0 5.677;  15500.0 4.052;  15750.0 2.575;  16000.0 1.302;
+                            16100.0 0.8697; 16200.0 0.4974; 16300.0 0.1989]
+
 """
-    _Hminus_bf_cross_section(ν)
+    _Hminus_bf_cross_section(λ)
 
-Compute the H⁻ bound-free cross-section, which has units of cm^2 per H⁻ particle.
+Compute the H⁻ bound-free cross-section at a given wavelength (specified in Å). The cross-section 
+has units of megabarns per H⁻ particle and does NOT include a correction for stimulated emission.
 
-The cross-section does not include a correction for stimulated emission.
+This function linearly interpolates the table provided in Wishart (1979).
 """
-function _Hminus_bf_cross_section(ν::Real)
-    λ = c_cgs*1e8/ν # in Angstroms
-    # we need to somehow factor out this bounds checking
-    if !(2250 <= λ <= 15000.0)
-        throw(DomainError(λ, "The wavelength must lie in the interval [2250 Å, 15000 Å]"))
-    end
-
-    λ2 = λ*λ
-    λ3 = λ*λ2
-    λ4 = λ*λ3
-    λ5 = λ*λ4
-    λ6 = λ*λ5
-
-    αbf_H⁻ = (1.99654 - 1.18267e-5 * λ + 2.64243e-6 * λ2 - 4.40524e-10 * λ3 + 3.23992e-14 * λ4
-              - 1.39568e-18 * λ5 + 2.78701e-23 * λ6)
-    αbf_H⁻ * 1e-18
-end
+const _Hminus_bf_cross_section = LinearInterpolation(view(_Hminus_bf_table, :, 1),
+                                                     view(_Hminus_bf_table, :, 2),
+                                                     extrapolation_bc=Throw())
 
 
 """
@@ -88,11 +92,14 @@ Compute the H⁻ bound-free opacity κ
 This function assumes that n(H⁻) ≪ n(H I) + n(H II). The number density of n(H⁻) should not be
 pre-computed (instead it's computed internally by this function).
 
-This function is adapted from equation 8.12 from Grey (2005). This equation gives the absorption
+This function is adapted from equation 8.12 from Grey (2005) This equation gives the absorption
 coefficient per H I atom (uncorrected by stimulated emission) is given by:
-    αff_H⁻ * 8.316e-10 * Pₑ * θ^2.5 * 10^(ion_energy_H⁻ * θ) * (U(H⁻,T)/ U(H I,T))
+
+    ``8.316e-10 \\alpha_{bf}(H^-) P_e \\theta^{2.5} * 10^{{\rm ion_energy_H}^- \\theta} U(H⁻,T)/ U(H I,T)``
+
 where:
-- αff_H⁻ is the photo dissociation cross-section. This can estimated with equation 8.11.
+- ``\\alpha_{bf}(H^-)`` is the photo dissociation cross-section. We estimate this by linearly
+  interpolating data from Wishart (1979).
 - θ = log10(e)/(k*T) or θ = 5040/T in units of eV⁻¹
 - U(H⁻,T) is the partition function of H⁻ at temperature T. This is always 1
 - U(H I,T) is the partition function of H I at temperature T. This is 2 at low to intermediate T.
@@ -101,26 +108,23 @@ Eqn 8.12 of Grey (2005) implicitly assumes that (U(H⁻,T)/ U(H I,T)) is always 
 This expression is simplicitly a rewritten form of: αff_H⁻ * n(H⁻)/n(H I) where n(H⁻)/n(H I) has
 been replaced with the expanded form of the saha equation, in which n₀ = n(H⁻) and n₁ = n(H I).
 
-Combining 8.18, and 8.19 of Gray (2005), indicate that the version opacity contribution of H⁻
-bound-free absorption (with stimulated emission correction) is given by:
+Combining 8.18, and 8.19 of Gray (2005), indicate that the opacity contribution of H⁻ bound-free
+absorption (with stimulated emission correction) is given by:
 
-                      n(H⁻)                                  n(H I)          n(H I) + n(H II)
-    κ_ν = α_bf(H⁻) * ------  * (1 - exp(-h*ν/(k*T))) * ------------------ * -----------------
-                     n(H I)                             n(H I) + n(H II)            ρ
+``\\kappa_\\nu = \\alpha_{bf}(H^-) \\frac{n(H^-)}{n(H I)} (1 - \\exp \\left( \\frac{-h\\nu}{k T}\\right) \\frac{n(H I)}{n(H I) + n(H II)} \\frac{n(H I) + n(H II)}{\\rho}``
 
-This can be rewritten as: κ_ν = α_bf(H⁻) * n(H⁻) * (1 - exp(-h*ν/(k*T))) / ρ
+This can be rewritten as: ``\\kappa_\\nu = \\alpha_{bf}(H^-) n(H⁻) (1 - \\exp \\left( \\frac{-h\\nu}{k T}\\right)  / \\rho``
 
-This function uses the polynomial provided in equation 8.11 of Gray (2005), that fits the tabulated
-data from Wishart (1979). While Gray (2005) claims that the polynomial fits the data with 0.2%
-precision for 2250 Å ≤ λ ≤ 15000 Å, in practice we find that it fits the data to better than 0.25%
-precision. Wishart (1979) expects the tabulated data to have better than 1% percent accuracy.
+Wishart (1979) expects the tabulated data to have better than 1% percent accuracy. Mathisen (1984)
+suggests that this data has better than 3% accuracy.
 """
 function Hminus_bf(nH_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real, 
                    ion_energy_H⁻::Real = 0.7552)
-    αbf_H⁻ = _Hminus_bf_cross_section(ν) # does not include contributions from stimulated emission
-    stimulated_emission_correction = (1 - exp(-hplanck_cgs*ν/(kboltz_cgs*T)))
-    n_H⁻ = _ndens_Hminus(nH_I_div_partition, ne, T, _H⁻_ion_energy)
-    αbf_H⁻ * n_H⁻ * stimulated_emission_correction / ρ
+    λ = c_cgs*1e8/ν # in ångstroms
+    tmp = _Hminus_bf_cross_section(λ) # in units of megabarn
+    # convert from megabarn to cm² and include contributions from stimulated emission  1e-18
+    αbf_H⁻ = (1 - exp(-hplanck_cgs*ν/(kboltz_cgs*T))) * tmp * 1e-18
+    _ndens_Hminus(nH_I_div_partition, ne, T, _H⁻_ion_energy) * αbf_H⁻ / ρ
 end
 
 

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -142,7 +142,7 @@ Wishart (1979) expects the tabulated data to have better than 1% percent accurac
 suggests that this data has better than 3% accuracy.
 """
 function Hminus_bf(nH_I_div_partition::Real, ne::Real, ν::Real, ρ::Real, T::Real, 
-                   ion_energy_H⁻::Real = 0.7552)
+                   ion_energy_H⁻::Real = _H⁻_ion_energy)
     λ = c_cgs*1e8/ν # in ångstroms
     tmp = _Hminus_bf_cross_section(λ, ion_energy_H⁻) # in units of megabarn
     # convert from megabarn to cm² and include contributions from stimulated emission  1e-18

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -83,7 +83,7 @@ function _Hminus_bf_cross_section(λ, ion_energy_H⁻)
     @assert max_λ_ionize > last_table_λ
 
     if λ < _Hminus_bf_table[1,1]
-        throw(DomainError(λ, "wavelength must be greater or equal to $(_Hminus_bf_table[1,1]) Å."))
+        throw(DomainError(λ, "λ must be ≥ $(_Hminus_bf_table[1,1]) Å"))
     elseif λ <= last_table_λ
         _Hminus_bf_cross_section_interp(λ)
     elseif λ <= max_λ_ionize

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -83,7 +83,7 @@ function _Hminus_bf_cross_section(λ, ion_energy_H⁻)
     @assert max_λ_ionize > last_table_λ
 
     if λ < _Hminus_bf_table[1,1]
-        throw(DomainError(λ, "$(_Hminus_bf_table[1,1]) Å must not exceed the wavelength"))
+        throw(DomainError(λ, "wavelength must be greater or equal to $(_Hminus_bf_table[1,1]) Å."))
     elseif λ <= last_table_λ
         _Hminus_bf_cross_section_interp(λ)
     elseif λ <= max_λ_ionize

--- a/test/continuum_opacity.jl
+++ b/test/continuum_opacity.jl
@@ -143,7 +143,7 @@ function check_Hminus_bf_values(target_precision = 0.002, verbose = true)
     comp_λ_vals = view(_bf_λ_vals, 5:56)
     comp_α_vals = view(_bf_α_vals, 5:56)
     @assert comp_λ_vals[1] == 2250.0
-    @assert comp_λ_vals[length(comp_λ_vals)] == 15000.0
+    @assert comp_λ_vals[end] == 15000.0
 
     coefs = _Hminus_bf_cross_section_Gray.(comp_λ_vals)
     precision = abs.(coefs .- comp_α_vals)./comp_α_vals
@@ -181,9 +181,8 @@ end
         T = 7800.0
 
         # determine the minimum and maximum λs in the table:
-        _table_length = size(Korg.ContinuumOpacity._Hminus_bf_table, 1)
         min_tabulated_λ = Korg.ContinuumOpacity._Hminus_bf_table[1,1]
-        max_tabulated_λ = Korg.ContinuumOpacity._Hminus_bf_table[_table_length, 1]
+        max_tabulated_λ = Korg.ContinuumOpacity._Hminus_bf_table[end, 1]
         # determine the ionization λ for H⁻:
         ion_energy = Korg.ContinuumOpacity._H⁻_ion_energy
         Å_per_eV = 1e8 * (Korg.hplanck_eV * Korg.c_cgs)

--- a/test/continuum_opacity.jl
+++ b/test/continuum_opacity.jl
@@ -105,27 +105,47 @@ end
     end
 end
 
+"""
+    _Hminus_bf_cross_section_Gray(λ)
+
+Compute the H⁻ bound-free cross-section at a given wavelength (specified in Å). The cross-section 
+has units of megabarns per H⁻ particle and does NOT include a correction for stimulated emission.
+
+This function uses the polynomial provided in equation 8.11 of Gray (2005), that fits the tabulated
+data from Wishart (1979). While Gray (2005) claims that the polynomial fits the data with 0.2%
+precision for 2250 Å ≤ λ ≤ 15000 Å, in practice we find that it fits the data to better than 0.25%
+precision.
+"""
+function _Hminus_bf_cross_section_Gray(λ::Real)
+    # we need to somehow factor out this bounds checking
+    if !(2250 <= λ <= 15000.0)
+        throw(DomainError(λ, "The wavelength must lie in the interval [2250 Å, 15000 Å]"))
+    end
+
+    λ2 = λ*λ
+    λ3 = λ*λ2
+    λ4 = λ*λ3
+    λ5 = λ*λ4
+    λ6 = λ*λ5
+
+    αbf_H⁻ = (1.99654 - 1.18267e-5 * λ + 2.64243e-6 * λ2 - 4.40524e-10 * λ3 + 3.23992e-14 * λ4
+              - 1.39568e-18 * λ5 + 2.78701e-23 * λ6)
+    αbf_H⁻
+end
+
 function check_Hminus_bf_values(target_precision = 0.002, verbose = true)
-    # this is the tabulated data from Wishart (1979)
-    _bf_table = [16300 0.1989; 16200 0.4974; 16100 0.8697; 16000 1.302; 15750 2.575; 15500 4.052;
-                 15250 5.677;  15000 7.407;  14750 9.211;  14500 11.07; 14250 12.95; 14000 14.85;
-                 13750 16.74;  13500 18.62;  13250 20.46;  13000 22.26; 12750 24.02; 12500 25.71;
-                 12250 27.33;  12000 28.87;  11750 30.34;  11500 31.72; 11250 33.01; 11000 34.19;
-                 10750 35.28;  10500 36.25;  10250 37.13;  10000 37.89; 9750 38.53;  9500 39.06;
-                 9250 39.48;   9000 39.77;   8750 39.95;   8500 40.01;  8250 39.95;  8000 39.77;
-                 7750 39.48;   7500 39.07;   7250 38.54;   7000 37.91;  6750 37.17;  6500 36.32;
-                 6250 35.37;   6000 34.32;   5750 33.17;   5500 31.94;  5250 30.62;  5000 29.23;
-                 4750 27.77;   4500 26.24;   4250 24.65;   4000 23.02;  3750 21.35;  3500 19.65;
-                 3250 17.92;   3000 16.19;   2750 14.46;   2500 12.75;  2250 11.08;  2000 9.453;
-                 1750 7.918;   1500 6.512;   1250 5.431]
+    # compare the tabulated data from Wishart (1979) against the polynomial fits from Gray (2005)
+    
+    _bf_table = Korg.ContinuumOpacity._Hminus_bf_table
+    _bf_λ_vals = view(_bf_table, :, 1)
+    _bf_α_vals = view(_bf_table, :, 2)
 
-    _bf_λ_vals = view(_bf_table, :, 1) # in Ångstroms
-    _bf_α_vals = view(_bf_table, :, 2) .* 1e-18 # in cm² per H⁻ particle.
-    comp_λ_vals = view(_bf_λ_vals, 8:59)
-    comp_α_vals = view(_bf_α_vals, 8:59)
-    ν_vals = (Korg.c_cgs*1e8)./comp_λ_vals
+    comp_λ_vals = view(_bf_λ_vals, 5:56)
+    comp_α_vals = view(_bf_α_vals, 5:56)
+    @assert comp_λ_vals[1] == 2250.0
+    @assert comp_λ_vals[length(comp_λ_vals)] == 15000.0
 
-    coefs = Korg.ContinuumOpacity._Hminus_bf_cross_section.(ν_vals)
+    coefs = _Hminus_bf_cross_section_Gray.(comp_λ_vals)
     precision = abs.(coefs .- comp_α_vals)./comp_α_vals
     max_err, max_err_ind = findmax(precision)
 


### PR DESCRIPTION
I altered `ContinuumOpacity.Hminus_bf` so that the cross-section is computed by directly interpolating data from Wishart (1979).

Previously, the cross-sections were computed using a polynomial from Gray (2005) that was fit to the tabulated data in Wishart (1979) while the tabulated data was used for verify the polynomial. Now, we use the Gray (2005) polynomial in our test to confirm that our transcription of the table is correct.

This change was primarily motivated by the fact directly using the table gives us opacities to wavelengths that are 1300 Å than before. 

While looking at [Mathisen (1984) ](https://inis.iaea.org/search/search.aspx?orig_q=RN:16033032), it clicked that the cross-section obviously goes to 0 at the ionization energy of H⁻.
- In other words,  there is no longer an upper wavelength limit where we don't know the H⁻ bound free opacity
- for reference, this zero-point is ~140 Å above the max wavelength in the table (in a part of the table where the wavelength spacing is 100 Å)
- my implementation for handling this is definitely not efficient. But I'm inclined to keep it until there is evidence that it is a performance bottleneck

I'm pretty confident that this addresses the IR solar spectrum discrepancy with `MOOG` that was described in PR #50. Here is the updated continuum spectrum:

![solar_comparison](https://user-images.githubusercontent.com/28722054/123729954-c39adc00-d863-11eb-8049-2ba3b97c6f6b.png)

I wanted to note one thing about what `MOOG`'s handling of the H⁻ bf opacity:
- They follow the suggestion of [Mathisen (1984) ](https://inis.iaea.org/search/search.aspx?orig_q=RN:16033032), and use a different data source for wavelengths from 180 Å to 1640 Å. 
    - My inclination is not to do this, since it doesn't really get us a whole lot since our current source gets down to 1250 Å. I could add a note about this to Issue #12 in case there's ever any interest in sythesizing UV spectra.
    - Moreover, there are apparently some resonance effects below 1250 Å, and that makes the accuracy of the other source a little questionable.