### PR TITLE
make air <--> vac functions autodetect units

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,24 +42,40 @@ function rectify(flux::AbstractVector{F}, wls; bandwidth=50, q=0.95) where F <: 
 end
 
 """
-    air_to_vacuum(λ)
+    air_to_vacuum(λ; cgs=λ<1)
 
-convert λ from an air wavelength to a vacuum wavelength
+convert λ from an air wavelength to a vacuum wavelength.  
+λ is assumed to be in Å if it is ⩾ 1, in cm otherwise.
+Formula from Birch and Downs (1994) via the VALD website.
 """
-function air_to_vacuum(λ)
+function air_to_vacuum(λ; cgs=λ<1)
+    if cgs
+        λ *= 1e8
+    end
     s = 1e4/λ
     n = 1 + 0.00008336624212083 + 0.02408926869968 / (130.1065924522 - s^2) + 0.0001599740894897 / (38.92568793293 - s^2)
+    if cgs
+        λ *= 1e-8
+    end
     λ * n
 end
 
 """
-    vacuum_to_air(λ)
+    vacuum_to_air(λ; cgs=λ<1)
 
 convert λ from a vacuum wavelength to an air wavelength
+λ is assumed to be in Å if it is ⩾ 1, in cm otherwise.
+Formula from Birch and Downs (1994) via the VALD website.
 """
-function vacuum_to_air(λ)
+function vacuum_to_air(λ; cgs=λ<1)
+    if cgs
+        λ *= 1e8
+    end
     s = 1e4/λ
     n = 1 + 0.0000834254 + 0.02406147 / (130 - s^2) + 0.00015998 / (38.9 - s^2)
+    if cgs
+        λ *= 1e-8
+    end
     λ / n
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -307,6 +307,23 @@ end
     @test argmax(convF) == 500
 end
 
+@testset "air <--> vacuum" begin
+    wls = collect(2000.0:π:10000.0)
+    @test vacuum_to_air.(air_to_vacuum.(wls)) ≈ wls rtol=1e-3
+    @test air_to_vacuum.(vacuum_to_air.(wls)) ≈ wls rtol=1e-3
+
+    #try it in cgs
+    wls .*= 1e8
+    @test vacuum_to_air.(air_to_vacuum.(wls)) ≈ wls rtol=1e-3
+    @test air_to_vacuum.(vacuum_to_air.(wls)) ≈ wls rtol=1e-3
+
+    #units should be automatically chosen
+    @test vacuum_to_air.(air_to_vacuum.(wls*1e-8)*1e8) ≈ wls rtol=1e-3
+    @test air_to_vacuum.(vacuum_to_air.(wls*1e-8)*1e8) ≈ wls rtol=1e-3
+    @test vacuum_to_air.(air_to_vacuum.(wls)*1e8)*1e-8 ≈ wls rtol=1e-3
+    @test air_to_vacuum.(vacuum_to_air.(wls)*1e8)*1e-8 ≈ wls rtol=1e-3
+end
+
 @testset "autodiff" begin
     using ForwardDiff
 


### PR DESCRIPTION
This fixes a bug for some linelists (not anything that impacts plots we've made so far).  