### PR TITLE
Change loop order & and improve line windowing

### DIFF
--- a/src/line_opacity.jl
+++ b/src/line_opacity.jl
@@ -58,6 +58,9 @@ function line_absorption!(α, linelist, λs, temp, nₑ, n_densities::Dict, part
 
         if !isnothing(α_cntm)
             α_crit = [cntm(line.wl) * cutoff_threshold for cntm in α_cntm]
+            if all(amplitude ./ α_crit .< 1e-10)
+                continue
+            end
             Δλ_crit = @. sqrt(amplitude * Δλ_L / α_crit) #where α from lorentz component == α_crit
             window_size = max(maximum(4Δλ_D), maximum(Δλ_crit))
         end


### PR DESCRIPTION
This changes the loop order from 
```
layers
    lines
        wavelengths
```
to
```
lines
    layers
       wavelengths
```
which remove a little bit of duplicate computation and is better for memory access.

It also revamps the line windowing code, with more precisely calculated cutoffs that save lots of time with small approximation error.

- TODO allow users to set `cutoff_threshold` 