### PR TITLE
Bugfix in `synthesize`

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -78,13 +78,13 @@ function synthesize(atm::ModelAtmosphere, linelist, λs::AbstractRange; metallic
     end
 
     for (i, layer) in enumerate(atm.layers)
-       if hydrogen_lines
-           α[i, :] .= α_cntm[i].(λs)
-           α[i, :] .+= hydrogen_line_absorption(λs, layer.temp, layer.electron_number_density, 
-                                                number_densities[literals.H_I][i], 
-                                                partition_funcs[literals.H_I], 
-                                                hline_stark_profiles, vmic*1e5)
-       end
+        α[i, :] .= α_cntm[i].(λs)
+        if hydrogen_lines
+            α[i, :] .+= hydrogen_line_absorption(λs, layer.temp, layer.electron_number_density, 
+                                                 number_densities[literals.H_I][i], 
+                                                 partition_funcs[literals.H_I], 
+                                                 hline_stark_profiles, vmic*1e5)
+        end
     end
 
     line_absorption!(α, linelist, λs, [layer.temp for layer in atm.layers], 


### PR DESCRIPTION
fixed a bug where `synthesize` only computes continuum opacities when it computes the hydrogen lines.