### PR TITLE
Fix default stark broadening values

### DIFF
--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -260,6 +260,7 @@ function approximate_gammas(wl, species, E_lower; ionization_energies=ionization
     nstar4_upper = (Z^2 * RydbergH_eV / (χ - E_upper))^2
     #I'm not actually able to reproduce Crowley 1971 equation 7 (his simplified form) from equation 
     #5, but these match the values in the Turbospectrum source, so they are probably correct.
+    #The constants here were calculated assuming that "v" is the mean (not modal) electron speed
     if Z == 1
         γstark = 2.25910152e-7 * nstar4_upper #Cowley (1971) equation 5 evaluated at T=10,000 K
     else

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -253,9 +253,11 @@ function approximate_gammas(wl, species, E_lower; ionization_energies=ionization
     k = kboltz_cgs
     E_upper = E_lower + (h * c / wl)
 
-    nstar4_upper = (Z^2 * Rydberg_eV / (χ - E_upper))^2
-    #From Cowley 1971
-    γstark = 0.77e-18 * nstar4_upper * wl^2
+    #It's not obvious to me which Rydberg constant to use here, and below in Δrbar2.  The sources
+    #are not entirely clear. It doesn't make a big difference.
+    nstar4_upper = (Z^2 * RydbergH_eV / (χ - E_upper))^2
+    #From Cowley 1971 - converted to freq units
+    γstark = 4.616803e-8 * nstar4_upper
 
     Δrbar2 = (5/2) * Rydberg_eV^2 * Z^2 * (1/(χ - E_upper)^2 - 1/(χ - E_lower)^2)
     if χ < E_upper

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -218,7 +218,8 @@ function Base.show(io::IO, m::MIME"text/plain", line::Line)
     print(io, " ", round(line.wl*1e8, digits=6), " Å")
 end
 
-""" approximate_radiative_gamma(wl, log_gf)
+"""
+    approximate_radiative_gamma(wl, log_gf)
 
 Approximate radiate broadening parameter.
 """
@@ -230,6 +231,8 @@ function approximate_radiative_gamma(wl, log_gf)
 end
 
 """
+    approximate_gammas(wl, species, E_lower; ionization_energies=Korg.ionization_energies)
+
 A simplified form of the Unsoeld (1955) approximation for van der Waals broadening and the 
 [Cowley 1971](https://ui.adsabs.harvard.edu/abs/1971Obs....91..139C/abstract) approximation for 
 Stark broadening, evaluated at 10,000 K. 

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -238,7 +238,8 @@ Returns γ_stark, log10(γ_vdW)
 In the calculation of n*², uses the approximation that
 \\overbar{r^2} = 5/2 {n^*}^4 / Z^2
 which neglects the dependence on the angular momentum quantum number, l, in the the form given by
-[Warner 1967](https://ui.adsabs.harvard.edu/abs/1967MNRAS.136..381W/abstract).
+[Warner 1967](https://ui.adsabs.harvard.edu/abs/1967MNRAS.136..381W/abstract) (which is the earliest
+english work reporting the Unsoeld result).
 
 For autoionizing lines (those for which E_upper > χ), returns 0.0 for γ_vdW.
 """
@@ -263,7 +264,8 @@ function approximate_gammas(wl, species, E_lower; ionization_energies=ionization
     if χ < E_upper
         γvdW = 0.0
     else
-        #(log) γ_vdW From R J Rutten's course notes. An equivalent form can be found in Gray 2005.
+        # (log) γ_vdW From R J Rutten's course notes. 
+        # Equations 11.29 and 11.30 from Gray 2005 are equivalent 
         γvdW = 6.33 + 0.4log10(Δrbar2) + 0.3log10(10_000) + log10(k)
     end
 

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -231,14 +231,14 @@ function approximate_radiative_gamma(wl, log_gf)
 end
 
 """
-A simplified form of the Unsoeld (1995) approximation for van der Waals and Stark broadening at 
+A simplified form of the Unsoeld (1955) approximation for van der Waals and Stark broadening at 
 10,000 K. Used for atomic lines with no vdW and stark broadening info in the linelist.
 Returns γ_stark, log10(γ_vdW)
 
 In the calculation of n*², uses the approximation that
 \\overbar{r^2} = 5/2 {n^*}^4 / Z^2
 which neglects the dependence on the angular momentum quantum number, l, in the the form given by
-Warner 1967.
+[Warner 1967](https://ui.adsabs.harvard.edu/abs/1967MNRAS.136..381W/abstract).
 
 For autoionizing lines (those for which E_upper > χ), returns 0.0 for γ_vdW.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,7 +233,7 @@ end
             @test linelist[2].vdW == linelist[1].vdW
 
             @test linelist[3].gamma_rad == linelist[2].gamma_rad
-            @test linelist[3].gamma_stark == 5.848503287015111e-25
+            @test linelist[3].gamma_stark == 0.0001903497656604677
             @test linelist[3].vdW == linelist[1].vdW
 
             @test linelist[4].gamma_rad == linelist[1].gamma_rad


### PR DESCRIPTION
I'm starting over with #64 because git is really confusing.

> Our default stark broadening is wrong. The Cowley formula is only for neutral species, but he cites Greim '68 for Stark broadening of ions. Also there's a unit problem: the formula I am using is in cm^-1, not s. Turbospec's code is useful, moog appears to be using a simpler approximation.
>
> Here I've addressed the unit problem, but I still need to correct the treatment of ions.

