### PR TITLE
easier synthesize signature (no need to explicitly construct range)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -438,6 +438,16 @@ using SpecialFunctions: expint
     @test Korg.exponential_integral_2.(xs) ≈ expint.(2, xs) rtol=1e-3
 end
 
+@testset "synthesize wavelength handling" begin
+    atm = read_model_atmosphere("data/sun.krz")
+    wls = 15000:0.01:15500
+    @test synthesize(atm, [], 15000, 15500).wavelengths ≈ wls
+    @test synthesize(atm, [], 15000, 15500; air_wavelengths=true).wavelengths ≈ Korg.air_to_vacuum.(wls)
+    @test_throws ArgumentError synthesize(atm, [], 15000, 15500; air_wavelengths=true, 
+                                          wavelength_conversion_warn_threshold=1e-20)
+    @test_throws ArgumentError synthesize(atm, [], 2000, 8000, air_wavelengths=true)
+end
+
 @testset "autodiff" begin
     using ForwardDiff
 


### PR DESCRIPTION
closes #89 (?)

This will make it easier to use frequencies internally later, and simplifies the interface for people calling into Korg from python.

I've also ensured that the constructed ranges use double-precision floats, which is _slightly_ less precise, but good enough for us, and may help with vectorization.