### PR TITLE
fix unit bug arising from me moving things around

### DIFF
--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -58,7 +58,7 @@ function line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_
         Δλ_L = maximum(inverse_lorentz_density.(ρ_crit, γ))
         window_size = max(Δλ_D, Δλ_L)
         lb, ub = move_bounds(λs, lb, ub, line.wl, window_size)
-        if lb >= ub
+        if lb > ub
             continue
         end
 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -107,7 +107,7 @@ function synthesize(atm::ModelAtmosphere, linelist, λs::AbstractRange; metallic
     end
 
     #discard lines far from the wavelength range being synthesized
-    linelist = filter(l-> λs[1] - line_buffer*1e-8 <= l.wl <= λs[end] + line_buffer*1e-8, linelist)
+    linelist = filter(l-> λs[1] - line_buffer <= l.wl <= λs[end] + line_buffer, linelist)
 
     abundances = get_absolute_abundances(metallicity, abundances, solar_abundances, solar_relative)
     MEQs = molecular_equilibrium_equations(abundances, ionization_energies, partition_funcs, 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -425,6 +425,22 @@ end
     @test_throws ArgumentError synthesize(atm, [], 2000, 8000, air_wavelengths=true)
 end
 
+@testset "line buffer" begin
+    #strong line at 4999 Å
+    line1 = Korg.Line(4999e-8, 1.0, Korg.species"Na I", 0.0)
+    #strong line at 4997 Å
+    line2 = Korg.Line(4997e-8, 1.0, Korg.species"Na I", 0.0)
+    atm = read_model_atmosphere("data/sun.mod")
+
+    #use a 2 Å line buffer so only line1 in included
+    sol_no_lines = synthesize(atm, [], 5000, 5000; line_buffer=2.0) #synthesize at 5000 Å only
+    sol_one_lines = synthesize(atm, [line1], 5000, 5000; line_buffer=2.0) 
+    sol_two_lines = synthesize(atm, [line1, line2], 5000, 5000; line_buffer=2.0) 
+
+    @test sol_no_lines.flux != sol_one_lines.flux
+    @test sol_two_lines.flux == sol_one_lines.flux
+end
+
 @testset "autodiff" begin
     using ForwardDiff
 


### PR DESCRIPTION
- [x] add test to catch this in the future

I had at some point introduced a unit bug (cm vs \AA) that caused the line buffer to effectively not work, so lines outside the synthesis range were ignored (10 \AA should be included by default).  This fixes it and introduces a test that will catch the bug if something similar happens again.

In writing the test I also fixed an error that prevented _any_ lines from contributing to wavelength if the wavelength range had one point.  (Probably no one will ever do that, but it should still work.)

This is good to merge.