### PR TITLE
LSF speed and accuracy

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,7 +57,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
     for i in 1:length(wls)
         λ0 = wls[i]
         σ = λ0 / R / 2
-        lb, ub = move_bounds(wls, lb, ub, λ0, σ)
+        lb, ub = move_bounds(wls, lb, ub, λ0, 3σ)
         ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
         normalization_factor[i] = 1 ./ sum(ϕ)
         @. convF[lb:ub] += flux[i]*ϕ

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,7 +62,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
         normalization_factor[i] = 1 ./ sum(ϕ)
         @. convF[lb:ub] += flux[i]*ϕ
     end
-    convF * normalization_factor
+    convF .* normalization_factor
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,9 +60,9 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
         lb, ub = move_bounds(wls, lb, ub, λ0, σ)
         ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
         normalization_factor[i] = 1 ./ sum(ϕ)
-        convF[lb:ub] .+= flux[i]*ϕ
+        @. convF[lb:ub] += flux[i]*ϕ
     end
-    convF .* normalization_factor
+    convF * normalization_factor
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,7 +60,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: Real
         lb, ub = move_bounds(wls, lb, ub, λ0, σ)
         ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
         normalization_factor[i] = 1 ./ sum(ϕ)
-        convF[lb:ub] += flux[i]*ϕ
+        convF[lb:ub] .+= flux[i]*ϕ
     end
     convF .* normalization_factor
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,11 +367,18 @@ end
     flux[500] = 5.0
 
     convF = Korg.constant_R_LSF(flux, wls, R)
+    convF_4sigma = Korg.constant_R_LSF(flux, wls, R; window_size=4)
+
     #normalized?
     @test sum(flux) ≈ sum(convF)
+    @test sum(flux) ≈ sum(convF_4sigma)
 
     #preserves line center?
     @test argmax(convF) == 500
+    @test argmax(convF_4sigma) == 500
+
+    #make sure the window_size argument is doing something
+    @test !(convF ≈ convF_4sigma)
 end
 
 @testset "air <--> vacuum" begin


### PR DESCRIPTION
This is not a replacement for truly fast LSF calculation, but it's a slight improvement.  It also fixes a bug in the LSF code.  Where I was smoothing only with a 1sigma wide kernel before (no idea wtf I was thinking), now I am smoothing with a 3sigma wide kernel.