### PR TITLE
make autodiff through atmosphere interpolation work (for now)

### DIFF
--- a/src/ContinuumAbsorption/ContinuumAbsorption.jl
+++ b/src/ContinuumAbsorption/ContinuumAbsorption.jl
@@ -43,9 +43,9 @@ The total continuum linear absoprtion coefficient, α, at many frequencies, ν.
     For efficiency reasons, `νs` must be sorted. While this function technically supports any 
     sorted `AbstractVector`, it is most effient when passed an  `AbstractRange`.
 """
-function total_continuum_absorption(νs::AbstractVector{F}, T::F, nₑ::F, number_densities::Dict,
-                                    partition_funcs::Dict; error_oobounds = false) where F <: Real
-    α = zeros(promote_type(F, valtype(number_densities)), length(νs))
+function total_continuum_absorption(νs, T, nₑ, number_densities::Dict, partition_funcs::Dict;
+                                    error_oobounds = false)
+    α = zeros(promote_type(eltype(νs), typeof(T), typeof(nₑ), valtype(number_densities)), length(νs))
 
     kwargs = Dict(:out_α => α, :error_oobounds => error_oobounds)
 

--- a/src/ContinuumAbsorption/absorption_metals_bf.jl
+++ b/src/ContinuumAbsorption/absorption_metals_bf.jl
@@ -36,11 +36,11 @@ function metal_bf_absorption!(α, νs, T, number_densities)
             end
             # cross-section interpolator
             σ_itp = metal_bf_cross_sections[spec]
-            σ = σ_itp.(νs, log10(T))
-            # Protecting this is necessary to avoid NaNs in derivatives.  
-            # It's probably better to avoid them in the first place for performance reasons.
-            mask = isfinite.(σ)
-            α[mask] .+= exp.(log(number_densities[spec]) .+ σ[mask]) * 1e-18 #convert to cm^2 
+            log_σ = σ_itp.(νs, log10(T))
+            # Using this mask is necessary to avoid NaNs in derivatives, which arise when σ = 0 and 
+            # log(σ) = -∞.
+            mask = isfinite.(log_σ)
+            α[mask] .+= exp.(log(number_densities[spec]) .+ log_σ[mask]) * 1e-18 #convert to cm^2 
         end
     end
 end

--- a/src/ContinuumAbsorption/absorption_metals_bf.jl
+++ b/src/ContinuumAbsorption/absorption_metals_bf.jl
@@ -36,8 +36,11 @@ function metal_bf_absorption!(α, νs, T, number_densities)
             end
             # cross-section interpolator
             σ_itp = metal_bf_cross_sections[spec]
-            α .+= exp.(log(number_densities[spec]) .+ σ_itp.(νs, log10(T))) * 1e-18 #convert to cm^2 
+            σ = σ_itp.(νs, log10(T))
+            # Protecting this is necessary to avoid NaNs in derivatives.  
+            # It's probably better to avoid them in the first place for performance reasons.
+            mask = isfinite.(σ)
+            α[mask] .+= exp.(log(number_densities[spec]) .+ σ[mask]) * 1e-18 #convert to cm^2 
         end
     end
-
 end

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -90,7 +90,7 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
             depth = parse(Float64, line[19:28])
             temp = parse(Float64, line[30:36])
             Pₑ = parse(Float64, line[39:48])
-            P = parse(Float64, line[51:60])
+            P = parse(Float64, line[50:60])
 
             nₑ = Pₑ / (temp*kboltz_cgs) # electron number density
             n = P / (temp*kboltz_cgs)   # non-electron number density

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -58,35 +58,35 @@ end
 This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
 memory-efficient order.
 """
-tau_5000s(atm::ModelAtmosphere) = [l.tau_5000 for l in atm.layers]
+get_tau_5000s(atm::ModelAtmosphere) = [l.tau_5000 for l in atm.layers]
 """
    zs(atm::ModelAtmosphere) = [l.z for l in atm.layers]
 
 This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
 memory-efficient order.
 """
-zs(atm::ModelAtmosphere) = [l.z for l in atm.layers]
+get_zs(atm::ModelAtmosphere) = [l.z for l in atm.layers]
 """
    temps(atm::ModelAtmosphere) = [l.temp for l in atm.layers]
 
 This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
 memory-efficient order.
 """
-temps(atm::ModelAtmosphere) = [l.temp for l in atm.layers]
+get_temps(atm::ModelAtmosphere) = [l.temp for l in atm.layers]
 """
    electron_number_densities(atm::ModelAtmosphere) = [l.electron_number_density for l in atm.layers]
 
 This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
 memory-efficient order.
 """
-electron_number_densities(atm::ModelAtmosphere) = [l.electron_number_density for l in atm.layers]
+get_electron_number_densities(atm::ModelAtmosphere) = [l.electron_number_density for l in atm.layers]
 """
     number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.layers]
 
 This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
 memory-efficient order.
 """
-number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.layers]
+get_number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.layers]
 
 """
     read_model_atmosphere(filename)

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -51,6 +51,43 @@ function Base.show(io::IO, m::MIME"text/plain", atm::A) where A <: ModelAtmosphe
     print(io, "$(A) with $(length(atm.layers)) layers")
 end
 
+#TODO add tests
+"""   
+    tau_5000s(atm::ModelAtmosphere) = [l.tau_5000 for l in atm.layers]
+
+This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
+memory-efficient order.
+"""
+tau_5000s(atm::ModelAtmosphere) = [l.tau_5000 for l in atm.layers]
+"""
+   zs(atm::ModelAtmosphere) = [l.z for l in atm.layers]
+
+This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
+memory-efficient order.
+"""
+zs(atm::ModelAtmosphere) = [l.z for l in atm.layers]
+"""
+   temps(atm::ModelAtmosphere) = [l.temp for l in atm.layers]
+
+This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
+memory-efficient order.
+"""
+temps(atm::ModelAtmosphere) = [l.temp for l in atm.layers]
+"""
+   electron_number_densities(atm::ModelAtmosphere) = [l.electron_number_density for l in atm.layers]
+
+This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
+memory-efficient order.
+"""
+electron_number_densities(atm::ModelAtmosphere) = [l.electron_number_density for l in atm.layers]
+"""
+    number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.layers]
+
+This is a convienince functions for making plots, etc.  Note that it doesn't access quantities in a 
+memory-efficient order.
+"""
+number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.layers]
+
 """
     read_model_atmosphere(filename)
 
@@ -89,11 +126,15 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
             logτ5 = parse(Float64, line[11:17])
             depth = parse(Float64, line[19:28])
             temp = parse(Float64, line[30:36])
-            Pₑ = parse(Float64, line[39:48])
-            P = parse(Float64, line[50:60])
+            Pe = parse(Float64, line[39:48])
+            Pg = parse(Float64, line[49:60])
 
-            nₑ = Pₑ / (temp*kboltz_cgs) # electron number density
-            n = P / (temp*kboltz_cgs)   # non-electron number density
+            # round negative pressures to 0
+            Pe = Pe * (Pe > 0)
+            Pg = Pg * (Pg > 0)
+
+            nₑ = Pe / (temp*kboltz_cgs) # electron number density
+            n = Pg/ (temp*kboltz_cgs)   # non-electron number density
 
             if planar
                 PlanarAtmosphereLayer(10^logτ5, -depth, temp, nₑ, n)

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -54,11 +54,9 @@ function line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_
         γ = @. Γ * line.wl^2 / c_cgs
 
         E_upper = line.E_lower + c_cgs * hplanck_eV / line.wl 
-        #levels_factor = (@. (exp(-β*line.E_lower) - exp(-β*E_upper)) / partition_fns[line.species](log(temp)))
         levels_factor = (@. (exp(-β*line.E_lower) - exp(-β*E_upper)))
 
         #total wl-integrated absorption coefficient
-        #amplitude = @. 10.0^line.log_gf*n_densities[line.species]*sigma_line(line.wl)*levels_factor
         amplitude = @. 10.0^line.log_gf*sigma_line(line.wl)*levels_factor*n_div_Z[line.species]
 
         ρ_crit = [cntm(line.wl) * cutoff_threshold for cntm in α_cntm] ./ amplitude

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -152,7 +152,8 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::Vector{<:Real}, λs::Ab
     end
     #put number densities in a dict of vectors, rather than a vector of dicts.
     n_dicts = first.(pairs)
-    number_densities = Dict([spec=>[n[spec] for n in n_dicts] for spec in keys(n_dicts[1])])
+    number_densities = Dict([spec=>[n[spec] for n in n_dicts] for spec in keys(n_dicts[1]) 
+                             if spec != species"H III"])
     #vector of continuum-absorption interpolators
     α_cntm = last.(pairs) 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,6 +301,13 @@ end
         @test atm.layers[1].temp == 4066.8
         @test atm.layers[1].electron_number_density ≈ 3.769664452210607e10
         @test atm.layers[1].number_density ≈ 4.75509171357701e14
+
+        # just make sure these don't error
+        Korg.tau_5000s(atm)
+        Korg.zs(atm)
+        Korg.temps(atm)
+        Korg.electron_number_densities(atm)
+        Korg.number_densities(atm)
     end
     @testset "spherical atmosphere" begin
         atm = Korg.read_model_atmosphere(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,11 +303,11 @@ end
         @test atm.layers[1].number_density ≈ 4.75509171357701e14
 
         # just make sure these don't error
-        Korg.tau_5000s(atm)
-        Korg.zs(atm)
-        Korg.temps(atm)
-        Korg.electron_number_densities(atm)
-        Korg.number_densities(atm)
+        Korg.get_tau_5000s(atm)
+        Korg.get_zs(atm)
+        Korg.get_temps(atm)
+        Korg.get_electron_number_densities(atm)
+        Korg.get_number_densities(atm)
     end
     @testset "spherical atmosphere" begin
         atm = Korg.read_model_atmosphere(


### PR DESCRIPTION
This generalizes some types, and addresses some inf/nan issues (see https://juliadiff.org/ForwardDiff.jl/stable/user/advanced/#Fixing-NaN/Inf-Issues) in the metal bf code.

It also precomputes n/U for each species in the linelist, rather than doing it for each line.

#133 should be merged first.