### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT
@@ -1,0 +1,38 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using Korg and for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: 
+    validations:
+      required: true
+  - type: textarea
+    id: julia_version
+    attributes:
+      label: Which version of Julia are you running?
+      description: You can check this by entering `julia -v` at your command line.
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: korg_version
+    attributes:
+      label: Which version of Korg are you running?
+      description: You can check this by entering `julia -e 'using Pkg; Pkg.status("Korg")'` at a command line.
+      value:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant Julia output. This will be automatically formatted into code, so no need for backticks.
+      render: julia

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT
@@ -20,7 +20,7 @@ body:
     id: julia_version
     attributes:
       label: Which version of Julia are you running?
-      description: You can check this by entering `julia -v` at your command line. We recommend Julia version 1.8 or higher, but please continue to submit your report because we want to make sure Korg works with all versions of Julia.
+      description: You can check this by entering `julia -v` at your command line. We always recommend using the [current stable release](https://julialang.org/downloads/) of Julia, but please continue to submit your report because we want to make sure Korg works with all versions of Julia.
       value:
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT
@@ -20,7 +20,7 @@ body:
     id: julia_version
     attributes:
       label: Which version of Julia are you running?
-      description: You can check this by entering `julia -v` at your command line.
+      description: You can check this by entering `julia -v` at your command line. We recommend Julia version 1.8 or higher, but please continue to submit your report because we want to make sure Korg works with all versions of Julia.
       value:
     validations:
       required: true


### PR DESCRIPTION
When I first used Julia I had no idea how to check which version I was using, or how to debug the stack trace. 

This template might make it easier for new Julia lovers to identify the versions of Julia and Korg that they're using when they create the report.