### PR TITLE
address Balmer line trunction

### DIFF
--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -154,13 +154,11 @@ Arguments:
 - `ξ`: microturbulent velocity [cm/s]. This is only applied to Hα-Hγ.  Other hydrogen lines profiles 
    are dominated by stark broadening, and the stark broadened profiles are pre-convolved with a 
    doppler profile.
-- `stark_window_size`: the max distance from each line center [cm] at which to calculate the stark
-   broadening profile
-- `self_window_size`: the max distance from each line center [cm] at which to calculate the line 
+- `window_size`: the max distance from each line center [cm] at which to calculate the stark
+   and self broadening profiles
    absorption for Hα-Hγ (those dominated by self-broadening).
 """
-function hydrogen_line_absorption!(αs, λs, T, nₑ, nH_I, UH_I, ξ; 
-                                   stark_window_size=3e-7, self_window_size=1e-6)
+function hydrogen_line_absorption!(αs, λs, T, nₑ, nH_I, UH_I, ξ; window_size=3e-6)
     νs = c_cgs ./ λs
     dνdλ = c_cgs ./ λs.^2
     #This is the Holtzmark field, by which the frequency-unit-detunings are divided for the 
@@ -199,7 +197,7 @@ function hydrogen_line_absorption!(αs, λs, T, nₑ, nH_I, UH_I, ξ;
             Γ = scaled_vdW((σ*bohr_radius_cgs^2, α), Hmass, T) * nH_I
             Δλ_L = Γ * λ₀^2 / c_cgs
 
-            lb, ub = move_bounds(λs, 0, 0, λ₀, self_window_size)
+            lb, ub = move_bounds(λs, 0, 0, λ₀, window_size)
             if lb == ub
                 continue
             end
@@ -207,7 +205,7 @@ function hydrogen_line_absorption!(αs, λs, T, nₑ, nH_I, UH_I, ξ;
         end
 
         #use Stehle+ 1999 Stark-broadened profiles
-        lb, ub = move_bounds(λs, 0, 0, λ₀, stark_window_size)
+        lb, ub = move_bounds(λs, 0, 0, λ₀, window_size)
         if lb == ub
             continue
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,7 +285,7 @@ include("statmech.jl")
         αs = zeros(length(wls))
         Korg.hydrogen_line_absorption!(αs, wls, 9000.0, 1e11, 1e13, 
                                        Korg.partition_funcs[Korg.species"H_I"](log(9000.0)), 0.0)
-        @test assert_allclose_grid(αs_ref, αs, [("λ", wls*1e8, "Å")]; rtol=1e-3)
+        @test assert_allclose_grid(αs_ref, αs, [("λ", wls*1e8, "Å")]; atol=1e-8)
     end
 end
 


### PR DESCRIPTION
This addresses #140.  It makes the H line window size larger by default, and enables setting it when calling `synthesize`.

```julia
using Revise, Korg, PyPlot

atm = read_model_atmosphere("../../Korg_data/marcs_mod/p8000_g+5.0_m0.0_t01_ap_z-1.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod");

smallsol = synthesize(atm, [], format_A_X(), 4700, 5000; hydrogen_line_window_size=30)
bigsol = synthesize(atm, [], format_A_X(), 4700, 5000; hydrogen_line_window_size=150)
sol = synthesize(atm, [], format_A_X(), 4700, 5000)

plot(smallsol.wavelengths, smallsol.flux, label="small window")
plot(bigsol.wavelengths, bigsol.flux, label="big window")
plot(sol.wavelengths, sol.flux, "--", label="default")

legend()
xlabel("wavelength")
ylabel("flux")
```
![image](https://user-images.githubusercontent.com/711963/201545957-1a7d4080-bcdc-49ee-9b4a-ee839eb6091f.png)

