### PR TITLE
correct LSF code to treat Δλ as the FWHM

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R; window_size=3) where F 
     lb, ub = 1,1 #initialize window bounds
     for i in 1:length(wls)
         λ0 = wls[i]
-        σ = λ0 / R / 2sqrt(2log(2)) # convert Δλ = λ0/R (FWHM) to sigma
+        σ = λ0 / R / (2sqrt(2log(2))) # convert Δλ = λ0/R (FWHM) to sigma
         lb, ub = move_bounds(wls, lb, ub, λ0, window_size*σ)
         ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
         normalization_factor[i] = 1 ./ sum(ϕ)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,8 +37,9 @@ end
     constant_R_LSF(flux, wls, R; window_size=3)
 
 Applies a gaussian line spread function the the spectrum with flux vector `flux` and wavelength
-vector `wls` with constant spectral resolution, ``R = \\lambda/\\Delta\\lambda``.  `window_size` 
-argument, specifies how far out to compute in the convolution kernel in standard deviations.
+vector `wls` with constant spectral resolution, ``R = \\lambda/\\Delta\\lambda``, where 
+``\\Delta\\lambda`` is the LSF FWHM.  The `window_size` argument specifies how far out to extend
+the convolution kernel in standard deviations.
 
 For the best match to data, your wavelength range should extend a couple ``\\Delta\\lambda`` outside 
 the region you are going to compare.
@@ -57,7 +58,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R; window_size=3) where F 
     lb, ub = 1,1 #initialize window bounds
     for i in 1:length(wls)
         λ0 = wls[i]
-        σ = λ0 / R / 2
+        σ = λ0 / R / 2sqrt(2log(2)) # convert Δλ = λ0/R (FWHM) to sigma
         lb, ub = move_bounds(wls, lb, ub, λ0, window_size*σ)
         ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
         normalization_factor[i] = 1 ./ sum(ϕ)


### PR DESCRIPTION
Fixes the error pointed out by @segasai in #134.