### PR TITLE
Interpolate marcs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "0.12.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -13,6 +13,7 @@ These functions are exported, so if you do `using Korg`, you can call them unqua
 synthesize
 read_linelist
 read_model_atmosphere
+interpolate_marcs
 format_A_X
 ```
 

--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -1,5 +1,5 @@
 module Korg
-    export synthesize, read_linelist, read_model_atmosphere, format_A_X
+    export synthesize, read_linelist, read_model_atmosphere, interpolate_marcs, format_A_X
 
     _data_dir = joinpath(@__DIR__, "../data") 
 

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -266,9 +266,12 @@ function interpolate_marcs(Teff, logg, Fe_H=0, alpha_Fe=0, C_Fe=0; spherical=log
     nodes, exists, grid = archive
 
     params = [Teff, logg, Fe_H, alpha_Fe, C_Fe]
+    param_names = ["Teff", "log(g)", "[Fe/H]", "[alpha/Fe]", "[C/Fe]"]
     
-    upper_vertex = map(zip(params, nodes)) do (p, p_nodes)
-        @assert p_nodes[1] <= p <= p_nodes[end]
+    upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)
+        if !(p_nodes[1] <= p <= p_nodes[end])
+            throw(ArgumentError("Can't interpolate atmosphere grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
+        end
         findfirst(p .<= p_nodes)
     end
     isexact = params .== getindex.(nodes, upper_vertex) #which params are on grid points?
@@ -314,7 +317,7 @@ function interpolate_marcs(Teff, logg, Fe_H=0, alpha_Fe=0, C_Fe=0; spherical=log
         end
     end
    
-    atm_quants = Float64.(structure[:, :, ones(Int, length(params))...])
+    atm_quants = (structure[:, :, ones(Int, length(params))...])
     if spherical
         R = sqrt(G_cgs * solar_mass_cgs / 10^(logg)) 
         ShellAtmosphere(ShellAtmosphereLayer.(atm_quants[:, 4], 

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -150,3 +150,101 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
         end
      end
 end
+
+module InterpolateSDSSMARCS 
+using HDF5: h5read
+using ..Korg: PlanarAtmosphere, PlanarAtmosphereLayer, ShellAtmosphere, ShellAtmosphereLayer
+
+atmosphere_archive = "../../korg_files/atmospheres/SDSS_MARCS_atmospheres.h5"
+
+#load from file
+planar_exists = h5read(atmosphere_archive, "planar/exists")
+planar_grid = h5read(atmosphere_archive, "planar/grid")
+planar_nodes = [h5read(atmosphere_archive, "planar/grid_values/$i") for i in 1:5]
+spherical_exists = h5read(atmosphere_archive, "spherical/exists")
+spherical_grid = h5read(atmosphere_archive, "spherical/grid")
+R_grid = h5read(atmosphere_archive, "spherical/R_grid")
+spherical_nodes = [h5read(atmosphere_archive, "spherical/grid_values/$i") for i in 1:5]
+
+function interpolate_marcs(Teff, logg, metallicity=0, alpha=0, carbon=0;
+        spherical=logg < 3.5,
+        nodes=(spherical ? spherical_nodes : planar_nodes),
+        exists=(spherical ? spherical_exists : planar_exists),
+        grid=(spherical ? spherical_grid : planar_grid),
+        R_grid=(spherical ? R_grid : nothing))
+
+    #TODO calculate R using M = 1
+    
+    params = [Teff, logg, metallicity, alpha, carbon]
+    
+    upper_vertex = map(zip(params, nodes)) do (p, p_nodes)
+        @assert p_nodes[1] <= p <= p_nodes[end]
+        findfirst(p .<= p_nodes)
+    end
+    isexact = params .== getindex.(nodes, upper_vertex) #which params are on grid points?
+    
+    # allocate 2^n cube for each quantity
+    dims = Tuple(2 for _ in upper_vertex) #dimensions of 2^n hypercube
+    structure_type = typeof(promote(Teff, logg, metallicity, alpha, carbon)[1])
+    structure = Array{structure_type}(undef, (56, 5, dims...))
+    if spherical
+        R = Array{structure_type}(undef, dims)
+    else
+        R = [0]
+    end
+     
+    #put bounding atmospheres in 2^n cube
+    for I in CartesianIndices(dims)
+        local_inds = collect(Tuple(I))
+        atm_inds = copy(local_inds)
+        atm_inds[isexact] .= 2 #use the "upper bound" as "lower bound" if the param is on a grid point
+        atm_inds .+= upper_vertex .- 2
+
+        if !exists[atm_inds...] #return nothing if any required nodes don't exist
+            println(getindex.(nodes, atm_inds), " doesn't exist") 
+            return 
+        end
+        
+        structure[:, :, local_inds...] .= grid[:, :, atm_inds...]
+        spherical && (R[local_inds...] = R_grid[atm_inds...])
+    end
+
+    for i in 1:length(params) #loop over Teff, logg, etc.
+        isexact[i] && continue #no need to do anything for exact params
+        
+        # the bounding values of the parameter you are currently interpolating over 
+        p1 = nodes[i][upper_vertex[i]-1]
+        p2 = nodes[i][upper_vertex[i]]
+        
+        # inds1 and inds2 are the expressions for the slices through the as-of-yet 
+        # uninterpolated quantities (temp, logPg, etc) for each node value of the
+        # quantity being interpolated
+        # inds1 = (1, 1, 1, ..., 1, 1, :, :, ...)
+        # inds2 = (1, 1, 1, ..., 1, 2, :, :, ...)
+        inds1 = vcat([1 for _ in 1:i-1], 1, [Colon() for _ in i+1:length(params)])
+        inds2 = vcat([1 for _ in 1:i-1], 2, [Colon() for _ in i+1:length(params)])
+        
+        x = (params[i] - p1) / (p2 - p1) #maybe try using masseron alpha later
+        for structure_ind in 1:5 #TODO fix
+            structure[:, structure_ind, inds1...] = (1-x)*structure[:, structure_ind, inds1...] + x*structure[:, structure_ind, inds2...]
+        end
+        if spherical
+            R[inds1...] = (1-x)*R[inds1...] + x*R[inds2...]
+        end
+    end
+    
+    Float64.(structure[:, :, ones(Int, length(params))...]), Float64(R[1])
+end
+
+function assemble_atm((m, R))
+    m, R = Float64.(m), Float64(R)
+    if R == 0
+        PlanarAtmosphere(PlanarAtmosphereLayer.(m[:, 4], sinh.(m[:, 5]), m[:, 1],
+                                                          exp.(m[:, 2]), exp.(m[:, 3])))
+    else
+        ShellAtmosphere(ShellAtmosphereLayer.(m[:, 4], sinh.(m[:, 5]), m[:, 1],
+                                                        exp.(m[:, 2]), exp.(m[:, 3])), R)
+    end
+end
+
+end

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -200,14 +200,14 @@ ratio.
 """
 function interpolate_marcs(archive, Teff, logg, A_X::Vector; kwargs...)
     Fe_H = A_X[26] - grevesse_2007_solar_abundances[26], A[X]
-    alpha_H = A_X[12] - grevesse_2007_solar_abundances[12] #TODO
-    C_H = mean(A_X[6] - grevesse_2007_solar_abundances[6], A[X])
-    interpolate_marcs(Teff, logg, Fe_H, alpha_H, C_H; kwargs...)
+    alpha_Fe = A_X[12]/A_X[26] - grevesse_2007_solar_abundances[12]/grevesse_2007_solar_abundances[26]
+    C_Fe = A_X[6]/A_x[26] - grevesse_2007_solar_abundances[6]/grevesse_2007_solar_abundances[26]
+    interpolate_marcs(Teff, logg, Fe_H, alpha_Fe, C_Fe; kwargs...)
 end
-function interpolate_marcs(archive, Teff, logg, Fe_H=0, alpha_H=0, C_H=0;
+function interpolate_marcs(archive, Teff, logg, Fe_H=0, alpha_Fe=0, C_Fe=0;
         spherical=logg < 3.5)
     nodes, exists, grid = archive
-    params = [Teff, logg, Fe_H, alpha_H, C_H]
+    params = [Teff, logg, Fe_H, alpha_Fe, C_Fe]
     
     upper_vertex = map(zip(params, nodes)) do (p, p_nodes)
         @assert p_nodes[1] <= p <= p_nodes[end]

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -252,7 +252,7 @@ with the `KORG_DATA_DIR` environment variable.
   default true when `logg` < 3.5.
 - `archive`: The atmosphere archive to use. For testing purposes.
 
-!!! note
+!!! warning
     Atmosphere interpolation is in beta.  Use with caution as it may be inaccurate.
 
 """

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -253,7 +253,7 @@ with the `KORG_DATA_DIR` environment variable.
 - `archive`: The atmosphere archive to use. For testing purposes.
 
 !!! note
-    Atmosphere interpolation is in beta.  Use with caution as it may be innacurate.
+    Atmosphere interpolation is in beta.  Use with caution as it may be inaccurate.
 
 """
 function interpolate_marcs(Teff, logg, A_X::Vector; kwargs...)

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -154,8 +154,14 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
      end
 end
 
+# this isn't a const because the model atmosphere doesn't get loaded into memory until 
+# interpolate_marcs is called for the first time
 global atmosphere_archive = nothing 
 
+"""
+Returns the local where Korg's large (too big for git) data files are stored.  At present, this is
+only the model atmosphere archive used by [`interpolate_marcs`](@ref).
+"""
 function _korg_data_dir()
     if "KORG_DATA_DIR" in keys(ENV)
         joinpath(ENV["KORG_DATA_DIR"])
@@ -178,7 +184,7 @@ function _load_atmosphere_archive()
 
             Korg.download_atmosphere_archive()
 
-        This will download the ~350 MB archive file and place it in ~/.korg/  If you would like 
+        This will download the ~370 MB archive file and place it in ~/.korg/  If you would like 
         to store it somewhere else, you can specify a location with the KORG_DATA_DIR environment 
         variable.
         """

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -182,12 +182,12 @@ function read_atmosphere_archive(path=joinpath(homedir(), ".korg", "SDSS_MARCS_a
 end
 
 """
-    interpolate_marcs(archive, Teff, logg, Fe_H=0, alpha_H=0, C_H=0)
+    interpolate_marcs(archive, Teff, logg, Fe_H=0, alpha_Fe=0, C_Fe=0)
     interpolate_marcs(archive, Teff, logg, A_X)
 
-Returns a model atmosphere obtained by interpolating the atmosphere grid `archive`.
+Returns a model atmosphere obtained by interpolating the atmosphere grid `archive`. 
 If the `A_X` (a vector of abundances in the format returned by [`format_A_X`](@ref) and accepted by 
-[`synthesize`](@ref).) is provided instead of `Fe_H`, `alpha_H`, and `C_H`, the solar-relative 
+[`synthesize`](@ref)) is provided instead of `Fe_H`, `alpha_Fe`, and `C_Fe`, the solar-relative 
 ratios will be reconstructed assuming Grevesse+ 2007 solar abundances, with Mg determining the alpha
 ratio.
 
@@ -217,7 +217,7 @@ function interpolate_marcs(archive, Teff, logg, Fe_H=0, alpha_Fe=0, C_Fe=0;
     
     # allocate 2^n cube for each quantity
     dims = Tuple(2 for _ in upper_vertex) #dimensions of 2^n hypercube
-    structure_type = typeof(promote(Teff, logg, Fe_H, alpha_H, C_H)[1])
+    structure_type = typeof(promote(Teff, logg, Fe_H, alpha_Fe, C_Fe)[1])
     structure = Array{structure_type}(undef, (56, 5, dims...))
      
     #put bounding atmospheres in 2^n cube

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -8,6 +8,9 @@ const electron_charge_cgs = 4.80320425e-10 # statcoulomb or cm^3/2 * g^1/2 / s
 const amu_cgs = 1.6605402e-24 #g
 const bohr_radius_cgs =  5.29177210903e-9 # cm 2018 CODATA recommended value
 
+const solar_mass_cgs = 1.9884e33  #g
+const G_cgs =  6.67430e-8 
+
 const eV_to_cgs = 1.602e-12 # ergs per eV
 
 const kboltz_eV = 8.617333262145e-5 #eV/K

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -258,7 +258,7 @@ end
 # it's important that this produces something parsable by the constructor
 function Base.show(io::IO, line::Line)
     show(io, line.species)
-    print(io, " ", round(line.wl*1e8, digits=6), " Å")
+    print(io, " ", round(line.wl*1e8, digits=6), " Å (log gf = ", round(line.log_gf, digits=2) ,")")
 end
 
 """

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -63,8 +63,8 @@ solution = synthesize(atm, linelist, A_X, 5000, 5100)
    defaults to `Korg.ionization_energies`.
 - `partition_funcs`, a `Dict` mapping `Species` to partition functions (in terms of ln(T)). Defaults 
    to data from Barklem & Collet 2016, `Korg.partition_funcs`.
-- `equilibrium_constants`, a `Dict` mapping `Species` representing diatomic molecules to base-10 log
-   of their molecular equilbrium constants in partial pressure form.  Defaults to data from 
+- `equilibrium_constants`, a `Dict` mapping `Species` representing diatomic molecules to the base-10
+   log of their molecular equilbrium constants in partial pressure form.  Defaults to data from 
    Barklem and Collet 2016, `Korg.equilibrium_constants`.
 - `bezier_radiative_transfer` (default: false): Use the radiative transfer scheme.  This is for 
    testing purposes only.

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -63,8 +63,8 @@ solution = synthesize(atm, linelist, A_X, 5000, 5100)
    defaults to `Korg.ionization_energies`.
 - `partition_funcs`, a `Dict` mapping `Species` to partition functions (in terms of ln(T)). Defaults 
    to data from Barklem & Collet 2016, `Korg.partition_funcs`.
-- `equilibrium_constants`, a `Dict` mapping `Species` representing diatomic molecules to their 
-   molecular equilbrium constants in partial pressure form.  Defaults to data from 
+- `equilibrium_constants`, a `Dict` mapping `Species` representing diatomic molecules to base-10 log
+   of their molecular equilbrium constants in partial pressure form.  Defaults to data from 
    Barklem and Collet 2016, `Korg.equilibrium_constants`.
 - `bezier_radiative_transfer` (default: false): Use the radiative transfer scheme.  This is for 
    testing purposes only.


### PR DESCRIPTION
This introduces code to automatically interpolated the SDSS MARCS atmosphere grid to whatever stellar parameters you like. The atmospheres are stored in an HDF5 file which is too big for github, which means we have to deal with it some other way. The plan is to store it in zenodo (could we use the SDSS server?).  

**option 1:** Make people manually download it and feed Korg its path.  
**option 2:**  When Korg is imported, check if `.korg/atmospherearchive.h5` exists, and automatically download it if it doesn't.  No idea how/if this would work on windows.
~~**option 3:** Don't use zenodo.  Pay for github LFS.  50GB of bandwidth per month is $5/month, which is very reasonable.  I'm happy to pay for this from my research budget, but if I stop doing for whatever reason it could be a snafu.  The other thing making this hard is that compiling Korg for CI would use all the bandwidth, so we would need a workaround for that.~~
**option 4:** Build a smaller grid into Korg, use option 1 if people want a better one.

Both options 2 and 3 have the problem that every time Korg is compiled by CI, the file gets re-downloaded.  I think we can work around this with an environmental variable, at least for option 2.  I think option 3 is the most technically elegant if the CI problems can be solved, but it has its own pitfalls.

TODO
- add tests (it's not clear that we can actually do this because of CI.  I could write a separate test suite to run on my personal computer.)
- resolve above quandary
- additional documentation (besides docstrings)?