### PR TITLE
Fix issue introduced in 0.15.0

### DIFF
--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -50,10 +50,11 @@ function translational_U(m, T)
 end
 
 """
-    get_nK(mol, T, log_equilibrium_constants)
+    get_inv_nK(mol, T, log_equilibrium_constants)
 
 Given a molecule, `mol`, a temperature, `T`, and a dictionary of log equilbrium constants in partial
-pressure form, return the equilibrium constant in number density form, i.e. `nK = n(A)n(B)/n(AB)`.
+pressure form, return the inverse equilibrium constant in number density form, i.e. `1/nK` where 
+`nK = n(A)n(B)/n(AB)`.
 """
 function get_inv_nK(mol, T, log_equilibrium_constants) 
     inv_nK = (kboltz_cgs*T)^(n_atoms(mol) - 1) / 10^log_equilibrium_constants[mol](log(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,7 +351,8 @@ end
         flux(p) = synthesize(atm, linelist, format_A_X(p[1], Dict("Ni"=>p[2])), 
                              wls; vmic=p[3]).flux
         #make sure this works.
-        ∇f = ForwardDiff.jacobian(flux, [0.0, 0.0, 1.5])
+        J = ForwardDiff.jacobian(flux, [0.0, 0.0, 1.5])
+        @test .! any(isnan.(J))
     end
 end
 


### PR DESCRIPTION
I introduced a problem in #155 which causes nans in autoderivatives.  This introduces a fix, as well as a test which will catch similar problems.  Unfortunately, this one wouldn't have been possible to catch easily since we can't test atmosphere interpolation in continuous integration.