### PR TITLE
strict checking of documentation, fix some of the problems

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.26"
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,25 @@ makedocs(sitename="Korg",
                 "Changelog" => "changelog.md"
                 "Developer Documentation" => "devdocs.md"
                ],
+        checkdocs = :all, # make sure all docstrings are in the documentation
+        linkcheck = true, # check if any external links are broken
+        linkcheck_ignore = [],
+        strict = [ # make these warnings into errors
+            :doctest,
+            :linkcheck,
+            :parse_error,
+            :example_block,
+            # This will error on duplicate functions docs, which we currently have by design
+            #:autodocs_block, 
+            :cross_references,
+            :docs_block, 
+            :eval_block,
+            :example_block,
+            :footnote,
+            :meta_block,
+            :missing_docs,
+            :setup_block
+        ],
         authors="Adam Wheeler and Matthew Abruzzo",
         format=Documenter.HTML(assets=["assets/favicon.ico"])
        )

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -2,7 +2,7 @@ This page docuements the Korg API for users of the package. Low-level functions 
 digging into the internals of Korg will be interested in can be found in the 
 [Developer documentation](@ref).
 
-# Top-level functions
+# [Top-level functions](@id API)
 If you are synthesize a spectrum Korg, these are the functions you will call.  
 These functions are exported, so if you do `using Korg`, you can call them unquallified (i.e.
 `synthesize` instead of `Korg.synthesize`).  
@@ -65,7 +65,7 @@ Korg.ContinuumAbsorption.He_II_bf
 Korg.ContinuumAbsorption.Heminus_ff
 Korg.ContinuumAbsorption.electron_scattering
 Korg.ContinuumAbsorption.rayleigh
-Korg.positive_ion_ff_absorption!
+Korg.ContinuumAbsorption.positive_ion_ff_absorption!
 Korg.ContinuumAbsorption.hydrogenic_bf_absorption
 Korg.ContinuumAbsorption.hydrogenic_ff_absorption
 ```

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -18,7 +18,6 @@ If you've never developed a package in Julia, here are some tips.
 - Unless they will never be called elsewhere, provide docstrings describing the inputs, assumptions and outputs of any functions you write.
 
 ## Continuum absorption
-
 Steps for implementing new continuum sources of absorption:
 - Define a helper function that computes a single absorption coefficient (in units of cm⁻²). The function should accept `ν` (in Hz) and `T` (in K) as the first and second arguments, respectively. The convention is for it should share a name with the corresponding public function, but have an underscore pre-appended (e.g. we define `_H_I_bf` to help implement `H_I_bf`).
 - The public function is the function constructed and returned by `Korg.ContinuumAbsorption.bounds_checked_absorption` that wraps the above helper function. This wrapper function implements bounds-checking for `ν` and `T` and supports the keyword arguments described in [Continuum Absorption Kwargs](@ref).
@@ -33,5 +32,6 @@ absorption from scattering).
 Here are all the documented methods in Korg.
 
 ```@autodocs
-Modules = [Korg, Korg.CubicSplines, Korg.ContinuumAbsorption, Korg.ContinuumAbsorption.Stancil1994, Korg.RadiativeTransfer, Korg.RadiativeTransfer.MoogStyleTransfer, Korg.RadiativeTransfer.BezierTransfer]
+Modules = [Korg, Korg.CubicSplines, Korg.ContinuumAbsorption, Korg.ContinuumAbsorption.Stancil1994,
+Korg.ContinuumAbsorption.Peach1970, Korg.RadiativeTransfer, Korg.RadiativeTransfer.MoogStyleTransfer, Korg.RadiativeTransfer.BezierTransfer]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,4 +5,4 @@ After [installing Korg](@ref install), get started by looking at the [top-level 
 If you are having trouble using or installing Korg, please get in touch by [opening a GitHub issue](https://github.com/ajwheeler/Korg.jl/issues) (preferred), or [sending Adam an email](mailto:wheeler.883@osu.edu).
 
 # Citing Korg
-If you use Korg in your research, please cite [our code paper](https://ui.adsabs.harvard.edu/abs/2022arXiv221100029W/abstract).  Thanks!
+If you use Korg in your research, please cite [our code paper](https://ui.adsabs.harvard.edu/abs/2023AJ....165...68W/abstract).  Thanks!

--- a/src/ContinuumAbsorption/Peach1970.jl
+++ b/src/ContinuumAbsorption/Peach1970.jl
@@ -1,53 +1,3 @@
-"""
-This module contains interpolators of the tabulated ff departure coeffients from 
-[Peach+ 1970](https://ui.adsabs.harvard.edu/abs/1970MmRAS..73....1P/abstract), which we use to 
-correct the hydrogenic ff absorption coefficient for H I ff, C I ff, Si I ff, and Mg I ff. 
-It contains a dictionary (returned by `departure_coefficients()`), which maps `Species` to 
-interpolator objects.  Crucially, the dictionary is indexed by the species which actually 
-participates in the interaction, not the one after which the interaction is named.  
-
-Outside the regime in which Peach 1970 provides data, the interpolators return 0, falling back to 
-the hydreogenic approximation.
-
-The species for which we use corrections are the same species which get corrected in 
-MARCS/Turbospectrum (see Table 1 of 
-[Gustafsson+ 2008](https://ui.adsabs.harvard.edu/abs/2008A%26A...486..951G/abstract)).
-The choices seem are largely motivated by which species have departure terms at normal
-stellar atmosphere conditions and which species are most abundant in the sun. For C II ff, 
-we include only the contribution from the ¹S parent term, even though (in contrast to other 
-speices) information is available for the ³Pᵒ term as well.
-
-The free-free absorption coefficient (including stimulated emission) is given by:
-
-``\\alpha_{\rm ff} = \\alpha_{\rm hydrogenic, ff}(\\nu, T, n_i, n_e; Z) (1 + D(T, \\sigma))``,
-
-where
-- ``\\alpha_{\rm hydrogenic, ff}(\\nu, T, n_i, n_e; Z)`` should include the correction for 
-  stimulated emission.
-- ``n_i`` is the number density fo the ion species that participates in the interation, not the 
-  species the interaction is named after.
-- ``n_e`` is the number density of free electrons.
-- ``D(T, \\sigma)`` is specified as the `departure` arg, and is expected to interpolate over
-the tabulated values specified in Table III of Peach (1970).
-- σ denotes the energy of the photon in units of RydbergH*Zeff²
-
-It might not be immediately obvious how the above equation relates to the equations presented in
-Peach (1970). Peach describes the calculation for ``k_\nu^F``, the free-free absorption 
-coefficient (uncorrected for stimulated emission) per particle of the species that the interaction 
-is named after. In other words, he computes:
- 
-``k_\nu^F = \\alpha_{\rm ff}/n_{i-1} \\left(1 - e^\\frac{-h\\nu}{k T}\\right)^{-1}``,
-
-where ``n_{i-1}`` is the number density of the species that the interaction is named after.
-``k_\nu^F`` can directly be computed, under LTE, from just ``\nu``, ``T``, and ``n_{i-1}`` (the
-Saha Equation relates ``\\alpha_{\rm ff}``'s dependence on ``n_e`` and ``n_i`` to ``n_{i-1}`` and 
-``T``.  Gray (2005) follows a similar convention when describing free-free absorption.
-
-!!! warning 
-    The tabulated data in this module was taken from Peach 1970 using OCR software, and may 
-    contain mis-read values, although they produce reasonable behavior and there are no obvious 
-    problems.
-"""
 module Peach1970
 
 using Interpolations: LinearInterpolation
@@ -325,6 +275,58 @@ coeffs[species"Mg II"] = let
     LinearInterpolation((T_vals, σ_vals), table_vals, extrapolation_bc=0)
 end
 
+"""
+    Peach1970.departure_coefficients()
+
+This module contains interpolators of the tabulated ff departure coeffients from 
+[Peach+ 1970](https://ui.adsabs.harvard.edu/abs/1970MmRAS..73....1P/abstract), which we use to 
+correct the hydrogenic ff absorption coefficient for H I ff, C I ff, Si I ff, and Mg I ff. 
+It contains a dictionary (returned by `departure_coefficients()`), which maps `Species` to 
+interpolator objects.  Crucially, the dictionary is indexed by the species which actually 
+participates in the interaction, not the one after which the interaction is named.  
+
+Outside the regime in which Peach 1970 provides data, the interpolators return 0, falling back to 
+the hydreogenic approximation.
+
+The species for which we use corrections are the same species which get corrected in 
+MARCS/Turbospectrum (see Table 1 of 
+[Gustafsson+ 2008](https://ui.adsabs.harvard.edu/abs/2008A%26A...486..951G/abstract)).
+The choices seem are largely motivated by which species have departure terms at normal
+stellar atmosphere conditions and which species are most abundant in the sun. For C II ff, 
+we include only the contribution from the ¹S parent term, even though (in contrast to other 
+speices) information is available for the ³Pᵒ term as well.
+
+The free-free absorption coefficient (including stimulated emission) is given by:
+
+``\\alpha_{\rm ff} = \\alpha_{\rm hydrogenic, ff}(\\nu, T, n_i, n_e; Z) (1 + D(T, \\sigma))``,
+
+where
+- ``\\alpha_{\rm hydrogenic, ff}(\\nu, T, n_i, n_e; Z)`` should include the correction for 
+  stimulated emission.
+- ``n_i`` is the number density fo the ion species that participates in the interation, not the 
+  species the interaction is named after.
+- ``n_e`` is the number density of free electrons.
+- ``D(T, \\sigma)`` is specified as the `departure` arg, and is expected to interpolate over
+the tabulated values specified in Table III of Peach (1970).
+- σ denotes the energy of the photon in units of RydbergH*Zeff²
+
+It might not be immediately obvious how the above equation relates to the equations presented in
+Peach (1970). Peach describes the calculation for ``k_\nu^F``, the free-free absorption 
+coefficient (uncorrected for stimulated emission) per particle of the species that the interaction 
+is named after. In other words, he computes:
+ 
+``k_\nu^F = \\alpha_{\rm ff}/n_{i-1} \\left(1 - e^\\frac{-h\\nu}{k T}\\right)^{-1}``,
+
+where ``n_{i-1}`` is the number density of the species that the interaction is named after.
+``k_\nu^F`` can directly be computed, under LTE, from just ``\nu``, ``T``, and ``n_{i-1}`` (the
+Saha Equation relates ``\\alpha_{\rm ff}``'s dependence on ``n_e`` and ``n_i`` to ``n_{i-1}`` and 
+``T``.  Gray (2005) follows a similar convention when describing free-free absorption.
+
+!!! warning 
+    The tabulated data in this module was taken from Peach 1970 using OCR software, and may 
+    contain mis-read values, although they produce reasonable behavior and there are no obvious 
+    problems.
+"""
 departure_coefficients() = coeffs
 
 end #module

--- a/src/ContinuumAbsorption/absorption_ff_positive_ion.jl
+++ b/src/ContinuumAbsorption/absorption_ff_positive_ion.jl
@@ -13,11 +13,11 @@ and the uncorrected hydrogenic approximation when they are not.
 - `T`: temperature in K
 - `number_densities` is a `Dict` mapping each `Species` to its number density.
 - `ne`: the number density of free electrons.
-- `departure_coefficients` (optional, defaults to [Peach1970](@ref)): 
+- `departure_coefficients` (optional, defaults to 
+   [ContinuumAbsorption.Peach1970.departure_coefficients](@ref)): 
    a dictionary mapping species to the departure coefficients for the ff process it participates in 
    (e.g. `species"C II"` maps to the C III ff departure coefficients--see note below).  Departure
    coefficients should be callables taking temperature and (photon energy / RydbergH / Zeff^2).  
-   See [Peach1970](@ref) for details.
 
 !!! note
     A free-free interaction is named as though the species interacting with the free electron had 

--- a/src/ContinuumAbsorption/absorption_ff_positive_ion.jl
+++ b/src/ContinuumAbsorption/absorption_ff_positive_ion.jl
@@ -14,7 +14,7 @@ and the uncorrected hydrogenic approximation when they are not.
 - `number_densities` is a `Dict` mapping each `Species` to its number density.
 - `ne`: the number density of free electrons.
 - `departure_coefficients` (optional, defaults to 
-   [ContinuumAbsorption.Peach1970.departure_coefficients](@ref)): 
+   `ContinuumAbsorption.Peach1970.departure_coefficients`: 
    a dictionary mapping species to the departure coefficients for the ff process it participates in 
    (e.g. `species"C II"` maps to the C III ff departure coefficients--see note below).  Departure
    coefficients should be callables taking temperature and (photon energy / RydbergH / Zeff^2).  

--- a/src/RadiativeTransfer/BezierTransfer.jl
+++ b/src/RadiativeTransfer/BezierTransfer.jl
@@ -3,8 +3,8 @@ Functions to solve the radiative transfer formal solution using the
 [de la Cruz Rodríguez and Piskunov method](https://ui.adsabs.harvard.edu/abs/2013ApJ...764...33D/abstract).
 
 We would like to migrate to this transfer implementation as the default eventually, but it doens't 
-seem to perform much better than [`MoogStyleTransfer`](@ref) in practice.  The treatment of both
-the path-length (ds) and what happens at the midplane of the star are more careful in this 
+seem to perform much better than `RadiativeTransfer.MoogStyleTransfer`` in practice.  The treatment 
+of both the path-length (ds) and what happens at the midplane of the star are more careful in this 
 implementation, but it's not yet as fast and it doesn't produce results any closer to the MARCS flux 
 files (even when adjusting the absorption coeffs to match the MARCS numbers).
 """

--- a/src/RadiativeTransfer/MoogStyleTransfer.jl
+++ b/src/RadiativeTransfer/MoogStyleTransfer.jl
@@ -1,5 +1,6 @@
 """
-Korg's default radiative transfer implementation. See also: [`BezierTransfer`](@ref)
+Korg's default radiative transfer implementation. 
+See also: `RadiativeTransfer.BezierTransfer`
 """
 module MoogStyleTransfer 
 using ..RadiativeTransfer: generate_mu_grid

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -11,7 +11,7 @@ Calculate the opacity coefficient, α, in units of cm^-1 from all lines in `line
 
 other arguments:
 - `temp` the temerature in K (at multiply layers, if you like)
-- `n_densities`, a Dict mapping species to absolute number density [cm^-3] (as a vector, if temp is
+- `n_densities`, a Dict mapping species to absolute number density in cm^-3 (as a vector, if temp is
    a vector).
 - `partition_fns`, a Dict containing the partition function of each species
 - `ξ` is the microturbulent velocity in cm/s (n.b. NOT km/s)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -251,7 +251,7 @@ format_A_X(abundances::Dict; kwargs...) = format_A_X(0, abundances; kwargs...)
     get_metals_H(A_X)
 
 Calculate [metals/H] given a vector, `A_X` of absolute abundances, ``A(X) = \\log_{10}(n_M/n_\\mathrm{H})``.
-See also [`get_A_alpha`](@ref).
+See also [`get_alpha_H`](@ref).
 """
 function get_metals_H(A_X; solar_abundances=asplund_2020_solar_abundances)
    _get_multi_X_H(A_X, 3:MAX_ATOMIC_NUMBER, solar_abundances)


### PR DESCRIPTION
This PR changes many Documenter.jl warnings to errors.  I still need to figure out how to get automatic cross-references working in a few instances, but this caught many problems immediately.