### PR TITLE
solve for ne instead of using atmospheric value

### DIFF
--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -131,7 +131,7 @@ function chemical_equilibrium(T, nₜ, model_atom_nₑ, absolute_abundances, ion
         number_densities[mol] = 10^(sum(element_log_ns) - log_nK)
     end
 
-    number_densities
+    nₑ, number_densities
 end
 
 function chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization_energies, 
@@ -163,14 +163,14 @@ function chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization
         F[1:end-1] .= atom_number_densities .- first.(ion_and_charge_factors) .* x[1:end-1]
         F[end] = sum(last.(ion_and_charge_factors) .* x[1:end-1]) - nₑ
 
-        #for (m, log_nK) in zip(molecules, log_nKs)
-        #    els = get_atoms(m.formula)
-        #    n_mol = 10^(sum(log10(x[el]) for el in els) - log_nK)
-        #    # RHS: atoms which are part of molecules
-        #    for el in els
-        #        F[el] -= n_mol
-        #    end
-        #end
+        for (m, log_nK) in zip(molecules, log_nKs)
+            els = get_atoms(m.formula)
+            n_mol = 10^(sum(log10(x[el]) for el in els) - log_nK)
+            # RHS: atoms which are part of molecules
+            for el in els
+                F[el] -= n_mol
+            end
+        end
     end
 end
 

--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -119,7 +119,8 @@ function chemical_equilibrium(T, nₜ, model_atm_nₑ, absolute_abundances, ioni
     # start with the neutral atomic species.  Only the absolute value of sol.zero is
     # necessarilly correct.
     nₑ = abs(sol.zero[end]) * nₜ * 1e-5
-    number_densities = Dict(Species.(Formula.(1:MAX_ATOMIC_NUMBER), 0) .=> nₜ * abs.(sol.zero[1:end-1]))
+    number_densities = Dict(Species.(Formula.(1:MAX_ATOMIC_NUMBER), 0) 
+                            .=> nₜ .* absolute_abundances .* abs.(sol.zero[1:end-1]))
     #now the ionized atomic species
     for a in 1:MAX_ATOMIC_NUMBER
         wII, wIII = saha_ion_weights(T, nₑ, a, ionization_energies, partition_fns)

--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -99,7 +99,6 @@ function chemical_equilibrium(T, nₜ, model_atm_nₑ, absolute_abundances, ioni
                               partition_fns, log_equilibrium_constants; x0=nothing)
     if x0 === nothing
         x_type = promote_type(eltype(absolute_abundances), typeof(model_atm_nₑ), typeof(T), typeof(nₜ))
-        println(x_type)
         x0 = Vector{x_type}(undef, MAX_ATOMIC_NUMBER + 1)
         #compute good first guess by neglecting molecules
         for Z in 1:MAX_ATOMIC_NUMBER
@@ -112,7 +111,7 @@ function chemical_equilibrium(T, nₜ, model_atm_nₑ, absolute_abundances, ioni
     #numerically solve for equlibrium.
     residuals! = chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization_energies, 
                                                 partition_fns, log_equilibrium_constants)
-    sol = nlsolve(residuals!, x0; iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
+    sol = nlsolve(residuals!, x0; method=:newton, iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
     if !sol.f_converged
         error("Molecular equlibrium unconverged. \n", sol)
     elseif !all(isfinite, sol.zero)

--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -112,7 +112,7 @@ function chemical_equilibrium(T, nₜ, model_atm_nₑ, absolute_abundances, ioni
     #numerically solve for equlibrium.
     residuals! = chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization_energies, 
                                                 partition_fns, log_equilibrium_constants)
-    sol = nlsolve(residuals!, x0; iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
+    sol = nlsolve(residuals!, x0; method=:newton, iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
     if !sol.f_converged
         error("Molecular equlibrium unconverged. \n", sol)
     elseif !all(isfinite, sol.zero)

--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -95,29 +95,31 @@ Equilibrium constants are defined in terms of partial pressures, so e.g.
 
     K(OH)  ==  (p(O) p(H)) / p(OH)  ==  (n(O) n(H)) / n(OH)) kT
 """
-function chemical_equilibrium(T, nₜ, model_atom_nₑ, absolute_abundances, ionization_energies, 
+function chemical_equilibrium(T, nₜ, model_atm_nₑ, absolute_abundances, ionization_energies, 
                               partition_fns, log_equilibrium_constants; x0=nothing)
     if x0 === nothing
         #compute good first guess by neglecting molecules
         x0 = map(1:MAX_ATOMIC_NUMBER) do atom
-            wII, wIII =  saha_ion_weights(T, model_atom_nₑ, atom, ionization_energies, partition_fns)
-            nₜ*absolute_abundances[atom] / (1 + wII + wIII)
+            wII, wIII =  saha_ion_weights(T, model_atm_nₑ, atom, ionization_energies, partition_fns)
+            1 / (1 + wII + wIII)
         end
-        push!(x0, model_atom_nₑ)
+        push!(x0, model_atm_nₑ / nₜ * 1e5)
     end
 
     #numerically solve for equlibrium.
-    sol = nlsolve(chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization_energies,
-                                                 partition_fns, log_equilibrium_constants),
-                  x0; iterations=1_000, store_trace=true, ftol=nₜ*1e-12, autodiff=:forward)
+    residuals! = chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization_energies, 
+                                                partition_fns, log_equilibrium_constants)
+    sol = nlsolve(residuals!, x0; method=:newton, iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
     if !sol.f_converged
         error("Molecular equlibrium unconverged. \n", sol)
+    elseif !all(isfinite, sol.zero)
+        error("Molecular equlibrium solution contains non-finite values.")
     end
 
     # start with the neutral atomic species.  Only the absolute value of sol.zero is
     # necessarilly correct.
-    nₑ = sol.zero[end]
-    number_densities = Dict(Species.(Formula.(1:MAX_ATOMIC_NUMBER), 0) .=> abs.(sol.zero[1:end-1]))
+    nₑ = abs(sol.zero[end]) * nₜ * 1e-5
+    number_densities = Dict(Species.(Formula.(1:MAX_ATOMIC_NUMBER), 0) .=> nₜ * abs.(sol.zero[1:end-1]))
     #now the ionized atomic species
     for a in 1:MAX_ATOMIC_NUMBER
         wII, wIII = saha_ion_weights(T, nₑ, a, ionization_energies, partition_fns)
@@ -143,33 +145,53 @@ function chemical_equilibrium_equations(T, nₜ, absolute_abundances, ionization
     # pressure, unlike those in equilibrium_constants.
     log_nKs = get_log_nK.(molecules, T, Ref(log_equilibrium_constants))
 
+    # precompute the ratio of singly and doubly ionized to neutral atoms with factors of nₑ^-1 and 
+    # nₑ^-2 divided out
+    pairs = map(1:MAX_ATOMIC_NUMBER) do Z
+        saha_ion_weights(T, 1, Z, ionization_energies, partition_fns)
+    end
+    wII_ne, wIII_ne2 = first.(pairs), last.(pairs)
 
-    #`residuals!` puts the residuals the system of molecular equilibrium equations in `F`
-    #`x` is a vector containing the number density of the neutral species of each element
-    function residuals!(F, x)
-        # Don't allow negative number densities.  This is a trick to bound the possible values 
-        # of x. Taking the log was less performant in tests.
-        x = abs.(x)
+    let nₜ=nₜ, log_nKs=log_nKs, molecules=molecules, atom_number_densities=atom_number_densities, wII_ne=wII_ne, wIII_ne2=wIII_ne2
+        #`residuals!` puts the residuals the system of molecular equilibrium equations in `F`
+        #`x` is a vector containing the number density of the neutral species of each element
+        function residuals!(F, x)
+            # Don't allow negative number densities.  This is a trick to bound the possible values 
+            # of x. Taking the log was less performant in tests.
+            x = abs.(x) #make a single copy of z, from here on, we can modify it in place
 
-        nₑ = x[end]
-                                    
-        # ion_factors is a vector of ( n(X I) + n(X II)+ n(X III) ) / n(X I) for each element X
-        ion_and_charge_factors = map(1:MAX_ATOMIC_NUMBER) do elem
-            wII, wIII = saha_ion_weights(T, nₑ, elem, ionization_energies, partition_fns)
-            (1 + wII + wIII), (wII + 2wIII)
-        end
+            # the first 92 elements of x are the fraction of each element in it's neutral atomic form
+            x[1:end-1] .*= atom_number_densities
 
-        # LHS: total number of atoms, RHS: first through third ionization states
-        F[1:end-1] .= atom_number_densities .- first.(ion_and_charge_factors) .* x[1:end-1]
-        F[end] = sum(last.(ion_and_charge_factors) .* x[1:end-1]) - nₑ
-
-        for (m, log_nK) in zip(molecules, log_nKs)
-            els = get_atoms(m.formula)
-            n_mol = 10^(sum(log10(x[el]) for el in els) - log_nK)
-            # RHS: atoms which are part of molecules
-            for el in els
-                F[el] -= n_mol
+            # the last is the electron number density in units of n_tot/10^5. The scaling allows us to 
+            # better specify the tolerance for the solver.
+            nₑ = x[end] * nₜ * 1e-5 
+            F[end] = 0
+                                        
+            # ion_factors is a vector of ( n(X I) + n(X II)+ n(X III) ) / n(X I) for each element X
+            for Z in 1:MAX_ATOMIC_NUMBER
+                wII = wII_ne[Z] / nₑ
+                wIII = wIII_ne2[Z] / nₑ^2
+                # LHS: total number of atoms, RHS: first through third ionization states
+                F[Z] = atom_number_densities[Z] - (1 + wII + wIII) * x[Z]
+                # RHS: electrons freed from each ion
+                F[end] += (wII + 2wIII) * x[Z]
             end
+            F[end] -= nₑ #LHS: total electron number density
+
+            # now the first 92 elements of x are log10(neutral number densities)
+            x[1:end-1] .= log10.(x[1:end-1])
+            for (m, log_nK) in zip(molecules, log_nKs)
+                els = get_atoms(m.formula)
+                n_mol = 10^(sum(x[el] for el in els) - log_nK)
+                # RHS: atoms which are part of molecules
+                for el in els
+                    F[el] -= n_mol
+                end
+            end
+
+            F[1:end-1] ./= atom_number_densities
+            F[end] /= nₑ * 1e-5
         end
     end
 end

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -149,7 +149,7 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::Vector{<:Real},
     end
 
     abs_abundances = @. 10^(A_X - 12) # n(X) / n_tot
-    abs_abundances ./= sum(abs_abundances) #normalize so that sum(N_x/N_total) = 1
+    abs_abundances ./= sum(abs_abundances) #normalize so that sum(n(X)/n_tot) = 1
 
     #float-like type general to handle dual numbers
     α_type = typeof(promote(atm.layers[1].temp, length(linelist) > 0 ? linelist[1].wl : 1.0, 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -28,6 +28,7 @@ A named tuple with keys:
    size (layers x wavelengths)
 - `number_densities`: A dictionary mapping `Species` to vectors of number densities at each 
    atmospheric layer
+- `electron_number_density`: the electron number density at each atmospheric layer
 - `wavelengths`: The vacuum wavelenths (in Å) over which the synthesis was performed.  If 
   `air_wavelengths=true` this will not be the same as the input wavelenths.
 - `subspectra`: A vector of ranges which can be used to index into `flux` to extract the spectrum 
@@ -217,7 +218,7 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::Vector{<:Real},
     end
 
     (flux=flux, intensity=intensity, alpha=α, number_densities=number_densities, 
-     wavelengths=all_λs.*1e8, subspectra=subspectra)
+    electron_number_density=nₑs, wavelengths=all_λs.*1e8, subspectra=subspectra)
 end
 
 """

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -164,7 +164,7 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::Vector{<:Real},
     # each layer's absorption at reference λ (5000 Å)
     # This isn't used with bezier radiative transfer.
     α5 = Vector{α_type}(undef, length(atm.layers)) 
-    tripples = map(enumerate(atm.layers)) do (i, layer)
+    triples = map(enumerate(atm.layers)) do (i, layer)
         nₑ, n_dict = chemical_equilibrium(layer.temp, layer.number_density, 
                                           layer.electron_number_density, 
                                           abs_abundances, ionization_energies, 
@@ -190,13 +190,13 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::Vector{<:Real},
 
         nₑ, n_dict, α_cntm_layer
     end
-    nₑs = first.(tripples)
+    nₑs = first.(triples)
     #put number densities in a dict of vectors, rather than a vector of dicts.
-    n_dicts = getindex.(tripples, 2)
+    n_dicts = getindex.(triples, 2)
     number_densities = Dict([spec=>[n[spec] for n in n_dicts] for spec in keys(n_dicts[1]) 
                              if spec != species"H III"])
     #vector of continuum-absorption interpolators
-    α_cntm = last.(tripples) 
+    α_cntm = last.(triples) 
 
     line_absorption!(α, linelist, wl_ranges, [layer.temp for layer in atm.layers], nₑs,
         number_densities, partition_funcs, vmic*1e5, α_cntm, cutoff_threshold=line_cutoff_threshold)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,11 +285,14 @@ end
 
     linelist = read_linelist("data/linelists/5000-5005.vald")
     wls = [6564:0.01:6565]
-    for atm_file in ["data/sun.mod",
-             "data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod"]
+    for (atm_file, threshold) in [("data/sun.mod", 0.1),
+             ("data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod", 100)]
         atm = read_model_atmosphere(atm_file)
-        flux(p) = synthesize(atm, linelist, format_A_X(p[1], Dict("Ni"=>p[2])), 
-                             wls; vmic=p[3]).flux
+        # the second model atmosphere happens to be in a weird (probably unphysical) part of 
+        # parameter space where the electron number densities calculated doesn't match the marcs
+        # numbers.  We suppress the warnings in this case by setting the threshold to 100.
+        flux(p) = synthesize(atm, linelist, format_A_X(p[1], Dict("Ni"=>p[2])), wls; 
+                             vmic=p[3], electron_number_density_warn_threshold=threshold).flux
         #make sure this works.
         J = ForwardDiff.jacobian(flux, [0.0, 0.0, 1.5])
         @test .! any(isnan.(J))

--- a/test/statmech.jl
+++ b/test/statmech.jl
@@ -52,11 +52,17 @@ end
         nX_ntot ./= sum(nX_ntot)
 
         nₜ = 1e15 
-        nₑ_initial_guess = 1e-5 * nₜ #arbitrary
+        nₑ_initial_guess = 1e12
         T = 5700
         nₑ, n_dict = Korg.chemical_equilibrium(T, nₜ, nₑ_initial_guess, nX_ntot, 
                                                Korg.ionization_energies, Korg.default_partition_funcs, 
-                                               Korg.default_log_equilibrium_constants; x0=nothing)
+                                               Korg.default_log_equilibrium_constants)
+
+        @test_logs (:warn, r"Electron number density differs") Korg.chemical_equilibrium(
+                                            T, nₜ, 1.0, nX_ntot, Korg.ionization_energies, 
+                                            Korg.default_partition_funcs, 
+                                            Korg.default_log_equilibrium_constants)
+        
 
         # plasma is net-neutral
         positive_charge_density =  mapreduce(+, pairs(n_dict)) do (species, n)

--- a/test/statmech.jl
+++ b/test/statmech.jl
@@ -52,11 +52,17 @@ end
         nX_ntot ./= sum(nX_ntot)
 
         nₜ = 1e15 
-        nₑ = 1e-3 * nₜ #arbitrary
+        nₑ_initial_guess = 1e-5 * nₜ #arbitrary
         T = 5700
-        nₑ, n_dict = Korg.chemical_equilibrium(T, nₜ, nₑ, nX_ntot, Korg.ionization_energies, 
-                                      Korg.default_partition_funcs, 
-                                      Korg.default_log_equilibrium_constants; x0=nothing)
+        nₑ, n_dict = Korg.chemical_equilibrium(T, nₜ, nₑ_initial_guess, nX_ntot, 
+                                               Korg.ionization_energies, Korg.default_partition_funcs, 
+                                               Korg.default_log_equilibrium_constants; x0=nothing)
+
+        # plasma is net-neutral
+        positive_charge_density =  mapreduce(+, pairs(n_dict)) do (species, n)
+            n * species.charge
+        end
+        @test nₑ ≈ positive_charge_density rtol=1e-5
 
         #make sure number densities are sensible
         @test (n_dict[Korg.species"C_III"] < n_dict[Korg.species"C_II"] < n_dict[Korg.species"C_I"] < 

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -23,7 +23,7 @@ end
     atm = read_model_atmosphere("data/sun.mod")
     bezier_sol = synthesize(atm, [], format_A_X(), 5000, 5001; bezier_radiative_transfer=true, n_mu_points=50)
     sol = synthesize(atm, [], format_A_X(), 5000, 5001 )
-    @test assert_allclose_grid(bezier_sol.flux, sol.flux, [("λ" , sol.wavelengths, "Å")]; rtol=0.025)
+    @test assert_allclose_grid(bezier_sol.flux, sol.flux, [("λ" , sol.wavelengths, "Å")]; rtol=0.03)
 end
 
 end


### PR DESCRIPTION
This branch is an experiment where Korg solves for the electron number density self-consistently, rather than assuming the model-atmospheric value is correct.  For the MARCS solar atmosphere, this adds about 0.1s to synthesis time, which is roughly double for a small wavelength range.

Notably, this implementation doesn't crash on any model atmospheres (at least at solar metallicity).  Contrast with the current method (#129), which sometimes fails for cool stars.

Here's the reletive difference in the $n_e$ that Korg infers using the old method and this one.  Solar atmosphere on the left, cool star (Teff = 3200K, logg=2.0 very close to the parameters which crash the current implementation) on the right:
![image](https://user-images.githubusercontent.com/711963/235231020-d6ca96f6-a569-43ca-af51-7a7c701d76d0.png)![image](https://user-images.githubusercontent.com/711963/235230887-f71cbcea-ed73-41af-874d-b46bc713b1d2.png)

The agreement between the methods is worse for the cool star, which is consistent with Korg's solver failing near there.  Completely unexpectedly (to me), the new method actually produces closer agreement with the model atmosphere pretty much everywhere. I'd really like to know what the cause for disagreement with the atmosphere is, but my guess is charged molecules.

The seems like a slam dunk except that it's slow.  

TODO 
- [x] actually use new ne for continuum stuff, etc
- [x] make fast?
- [x] document changes in atmosphere code
- [x] add warning when electron number density diverges from model atmosphere
- [x] stress test to see where, if anywhere, Korg's chemical equilibrium can't converge