### PR TITLE
docstring fixes

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -96,10 +96,6 @@ get_number_densities(atm::ModelAtmosphere) = [l.number_density for l in atm.laye
 
 Parse the provided model atmosphere file in MARCS ".mod" format.  Returns either a 
 `PlanarAtmosphere` or a `ShellAtmosphere`.
-
-!!! warning
-    Korg does not yet support cool (``\\lesssim`` 3500 K) stars.  While it will happily parse their
-    model atmospheres, it may crash when you feed them into `synthesize`.
 """
 function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
     open(fname) do f

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -131,11 +131,11 @@ function validate_params(initial_guesses, fixed_params;
 end
 
 """
+    find_best_fit_params(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fixed_params; kwargs...)
+
+
 !!! warning
     This is in beta. It's API may change.  Use at your own risk.
-
-
-    find_best_fit_params(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fixed_params; kwargs...)
 
 Find the parameters and abundances that best match a rectified observed spectrum.
 

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -303,7 +303,7 @@ end
 The oscillator strength of the transition from the nth to the mth energy level of hydrogen. 
 Adapted from HLINOP.f by Peterson and Kurucz. Used for Brackett lines only.
 
-Comparison to the values in [Goldwire 1968](doi.org/10.1086/190180) indicates that this is accurate 
+Comparison to the values in [Goldwire 1968](https://doi.org/10.1086/190180) indicates that this is accurate 
 to 10^-4 for the Brackett series.
 """
 function hydrogen_oscillator_strength(n, m)
@@ -323,7 +323,7 @@ end
 
 Normalize stark-broadened line profile (specialized to Brackett series).  Translated and heavily
 adapted from HLINOP.f by Barklem, who adapted it from Peterson and Kurucz.  Mostly follows 
-[Griem 1960](doi.org/10.1086/146987), and [Griem 1967](doi.org/10.1086/149097).  Ions and distant
+[Griem 1960](https://doi.org/10.1086/146987), and [Griem 1967](https://doi.org/10.1086/149097).  Ions and distant
 electrons have E fields which can be treated quasi-statically, leading to a
 [Holtsmark broadening profile](https://doi.org/10.1002/andp.19193630702).
 
@@ -446,7 +446,7 @@ const _greim_Kmn_table = [
     ]
 
 """
-Knm constants as defined by [Griem 1960](doi.org/10.1086/146987) for the long range Holtsmark 
+Knm constants as defined by [Griem 1960](https://doi.org/10.1086/146987) for the long range Holtsmark 
 profile. Does not include the preferred values for non-Brackett lines.
 """
 function greim_1960_Knm(n, m)
@@ -506,7 +506,7 @@ const _holtsmark_β_knots = [1.,1.259,1.585,1.995,2.512,3.162,3.981,
 
 Calculates the Holtsmark profile for broadening of hydrogen lines by quasistatic charged particles.
 Adapted from SOFBET in HLINOP by Peterson and Kurucz. Draws heavily from 
-[Griem 1960](doi.org/10.1086/146987).
+[Griem 1960](https://doi.org/10.1086/146987).
 """
 function holtsmark_profile(β,P)
 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -10,7 +10,7 @@ Compute a synthetic spectrum.
 
 # Arguments
 - `atm`: the model atmosphere (see [`read_model_atmosphere`](@ref))
-- `linelist`: A vector of [`Line]`(@ref)s (see [`read_linelist`](@ref))
+- `linelist`: A vector of [`Line`](@ref)s (see [`read_linelist`](@ref))
 - `A_X`: a vector containing the A(X) abundances (log(X/H) + 12) for elements from hydrogen to 
   uranium.  (see [`format_A_X`](@ref))
 - `λ_start`: the lower bound (in Å) of the region you wish to synthesize.


### PR DESCRIPTION
This cleans up a few things introduced by #197  and some outstanding docs formatting problems.  It also removes the warning about #129, which is almost completely solved.