### PR TITLE
git bracket line nans in line core; catch with tests

### DIFF
--- a/src/hydrogen_line_absorption.jl
+++ b/src/hydrogen_line_absorption.jl
@@ -335,6 +335,7 @@ function brackett_line_stark_profiles(m, λs, λ₀, T, nₑ)
     # the gamma function. 
     ps = (0.9*y1).^2
     quasistatic_e_contrib = @. (ps+0.03*sqrt(y1))/(ps+1.)
+    quasistatic_e_contrib[quasistatic_e_contrib .== 0] .= 0 # fix autodiff NaNs from 0/0
 
     total_quasistatic_profile = @. quasistatic_ion_contribution * (1+quasistatic_e_contrib) 
     # this correction makes the profile not normalized.  It's unclear to me that we should be 

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -4,7 +4,7 @@
     linelist = read_linelist("data/linelists/5000-5005.vald")
 
     #cover the optical and the IR to catch different H lines 
-    wls = [6564:0.01:6565, 15_250:0.01:15_251] 
+    wls = [6564:0.01:6565, 15_045:0.01:15_046] 
     for (atm_file, threshold) in [("data/sun.mod", 0.1),
              ("data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod", 100)]
         atm = read_model_atmosphere(atm_file)


### PR DESCRIPTION
There are nans in the brackett line derivatives arising from an undefined division. The test that should have caught this has been fixed to test wavelengths close enough to a brackett line.