### PR TITLE
gracefully handle truncated VALD linelists

### DIFF
--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -276,7 +276,12 @@ end
 
 function parse_vald_linelist(f, isotopic_abundances)
     lines = filter!(collect(eachline(f))) do line
-        length(line) > 0 && line[1] != '#' #remove comments and empty lines
+        length(line) > 0 && line[1] != '#' # remove comments and empty lines
+    end
+
+    # ignore truncation warning
+    if startswith(lines[1],  " WARNING: Output was truncated to 100000 lines")
+        lines = lines[2:end]
     end
 
     lines = replace.(lines, "'"=>"\"") #replace single quotes with double

--- a/test/data/linelists/long-extract-all-air-wavenumber-noquotes.vald
+++ b/test/data/linelists/long-extract-all-air-wavenumber-noquotes.vald
@@ -1,3 +1,4 @@
+ WARNING: Output was truncated to 100000 lines #obviously not true, this is here for testing
                                                                                Lande factors        Damping parameters
 Elm Ion       WL_air(A)  log gf* E_low(cm^-1)   J lo  E_up(cm^-1)   J up   lower   upper    mean   Rad.  Stark    Waals
 'Ti 1',      4998.72899,  -0.760,  25102.875,    2.0,  45102.381,    3.0,  1.930,  1.360,  0.780, 7.970,-5.260,  -7.540


### PR DESCRIPTION
When VALD linelists are too long, they get truncated and a warning is added to the beginning of the file. This PR allows Korg to parse anyway.