### PR TITLE
Allow LSFs with R as a function of wavelength

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -29,7 +29,7 @@ doing.
 These are used to transform observational or synthetic spectra.
 
 ```@docs
-Korg.constant_R_LSF
+Korg.apply_LSF
 Korg.compute_LSF_matrix
 Korg.air_to_vacuum
 Korg.vacuum_to_air

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -83,7 +83,7 @@ function line_spread_function_core(synth_wls, λ0, R, window_size, renormalize_e
 end
 
 """
-    constant_R_LSF(flux, wls, R; window_size=4)
+    apply_LSF(flux, wls, R; window_size=4)
 
 Applies a gaussian line spread function the the spectrum with flux vector `flux` and wavelength
 vector `wls` with constant spectral resolution, ``R = \\lambda/\\Delta\\lambda``, where 
@@ -104,11 +104,11 @@ will get much better performance using [`compute_LSF_matrix`](@ref).
 !!! warning
     - This is a naive, slow implementation.  Do not use it when performance matters.
 
-    - `constant_R_LSF` will have weird behavior if your wavelength grid is not locally linearly-spaced.
+    - `apply_LSF` will have weird behavior if your wavelength grid is not locally linearly-spaced.
        It is intended to be run on a fine wavelength grid, then downsampled to the observational (or 
        otherwise desired) grid.
 """
-function constant_R_LSF(flux::AbstractVector{F}, wls, R; window_size=4, renormalize_edge=true) where F <: Real
+function apply_LSF(flux::AbstractVector{F}, wls, R; window_size=4, renormalize_edge=true) where F <: Real
     #ideas - require wls to be a range object? 
     convF = zeros(F, length(flux))
     normalization_factor = Vector{F}(undef, length(flux))
@@ -119,6 +119,7 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R; window_size=4, renormal
     end
     convF .* normalization_factor
 end
+@deprecate constant_R_LSF(args...; kwargs...) apply_LSF(args...; kwargs...)
 
 """
     compute_LSF_matrix(synth_wls, obs_wls, R; kwargs...)
@@ -145,7 +146,7 @@ Construct a sparse matrix, which when multiplied with a flux vector defined over
 For the best match to data, your wavelength range should extend a couple ``\\Delta\\lambda`` outside 
 the region you are going to compare. 
 
-[`Korg.constant_R_LSF`](@ref) can apply an LSF to a single flux vector efficiently. This function is
+[`Korg.apply_LSF`](@ref) can apply an LSF to a single flux vector efficiently. This function is
 relatively slow, but one the LSF matrix is constructed, convolving spectra to observational 
 resolution via matrix multiplication is fast.
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -112,7 +112,6 @@ function constant_R_LSF(flux::AbstractVector{F}, wls, R; window_size=4, renormal
     #ideas - require wls to be a range object? 
     convF = zeros(F, length(flux))
     normalization_factor = Vector{F}(undef, length(flux))
-    lb, ub = 1,1 #initialize window bounds
     for i in eachindex(wls)
         λ0 = wls[i]
         r, ϕ, normalization_factor[i] =  line_spread_function_core(wls, λ0, R, window_size, renormalize_edge)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,12 +241,12 @@ end
     @test Korg.compute_LSF_matrix(array_wls, obs_wls, R) ≈ Korg.compute_LSF_matrix(range_wls, obs_wls, R) 
     @test_throws ArgumentError Korg.compute_LSF_matrix(array_wls, obs_wls, R; step_tolerance=1e-9)
 
-    convF = Korg.constant_R_LSF(flux, wls, R)
-    convF_5sigma = Korg.constant_R_LSF(flux, wls, R; window_size=5)
+    convF = Korg.apply_LSF(flux, wls, R)
+    convF_5sigma = Korg.apply_LSF(flux, wls, R; window_size=5)
     convF_mat = Korg.compute_LSF_matrix(wls, wls, R) * flux
     convF_mat5 = Korg.compute_LSF_matrix(wls, wls, R; window_size=5) * flux
     convF_mat_vec = Korg.compute_LSF_matrix([5900:0.35:5935, 5935.35:0.35:6100], wls, R) * flux
-    convF_changing_R = Korg.constant_R_LSF(flux, wls, wl->wl/6000*R)
+    convF_changing_R = Korg.apply_LSF(flux, wls, wl->wl/6000*R)
     convF_mat_changing_R = Korg.compute_LSF_matrix(wls, wls, wl->wl/6000*R) * flux
 
     @test convF_mat_changing_R ≈ convF_changing_R rtol=1e-10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,9 @@ end
     # should't matter if you split wls into 2 ranges
     @test Korg.compute_LSF_matrix([5900:0.35:5935, 5935.35:0.35:6100], wls, R) ≈ Korg.compute_LSF_matrix(wls, wls, R) 
 
+    # should't matter if R is a function
+    @test Korg.compute_LSF_matrix(wls, wls, wl->R) ≈ Korg.compute_LSF_matrix(wls, wls, R) 
+
     # synth_wls can be a slightly fuzzy grid
     obs_wls = 5000 : 1.0 : 5010
     range_wls = 5000 : 0.01 : 5010
@@ -243,8 +246,12 @@ end
     convF_mat = Korg.compute_LSF_matrix(wls, wls, R) * flux
     convF_mat5 = Korg.compute_LSF_matrix(wls, wls, R; window_size=5) * flux
     convF_mat_vec = Korg.compute_LSF_matrix([5900:0.35:5935, 5935.35:0.35:6100], wls, R) * flux
+    convF_changing_R = Korg.constant_R_LSF(flux, wls, wl->wl/6000*R)
+    convF_mat_changing_R = Korg.compute_LSF_matrix(flux, wls, wl->wl/6000*R) * flux
+
     downsampled_wls = 5950:0.4:6050
     convF_mat_downsample = Korg.compute_LSF_matrix(wls, downsampled_wls, R; window_size=5) * flux
+
 
     # normalized?
     @test sum(flux) ≈ sum(convF)  rtol=1e-3
@@ -254,6 +261,8 @@ end
     @test sum(flux) ≈ sum(convF_mat5) rtol=1e-3
     @test sum(flux) ≈ sum(convF_mat_vec) rtol=1e-3
     @test sum(flux) * step(wls) ≈ sum(convF_mat_downsample) * step(downsampled_wls) rtol=1e-3
+    @test sum(flux) ≈ sum(convF_changing_R) rtol=1e-3
+    @test sum(flux) ≈ sum(convF_mat_changing_R) rtol=1e-3
 
     # preserves line center?
     @test argmax(convF) == spike_ind
@@ -261,6 +270,8 @@ end
     @test argmax(convF_mat) == spike_ind
     @test argmax(convF_mat5) == spike_ind
     @test argmax(convF_mat_vec) == spike_ind
+    @test argmax(convF_changing_R) == spike_ind
+    @test argmax(convF_mat_changing_R) == spike_ind
 
     # make sure the default window_size values are OK
     @test assert_allclose(convF, convF_mat5; atol=1e-4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,6 +249,8 @@ end
     convF_changing_R = Korg.constant_R_LSF(flux, wls, wl->wl/6000*R)
     convF_mat_changing_R = Korg.compute_LSF_matrix(wls, wls, wl->wl/6000*R) * flux
 
+    @test convF_mat_changing_R ≈ convF_changing_R rtol=1e-10
+
     downsampled_wls = 5950:0.4:6050
     convF_mat_downsample = Korg.compute_LSF_matrix(wls, downsampled_wls, R; window_size=5) * flux
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,11 +247,10 @@ end
     convF_mat5 = Korg.compute_LSF_matrix(wls, wls, R; window_size=5) * flux
     convF_mat_vec = Korg.compute_LSF_matrix([5900:0.35:5935, 5935.35:0.35:6100], wls, R) * flux
     convF_changing_R = Korg.constant_R_LSF(flux, wls, wl->wl/6000*R)
-    convF_mat_changing_R = Korg.compute_LSF_matrix(flux, wls, wl->wl/6000*R) * flux
+    convF_mat_changing_R = Korg.compute_LSF_matrix(wls, wls, wl->wl/6000*R) * flux
 
     downsampled_wls = 5950:0.4:6050
     convF_mat_downsample = Korg.compute_LSF_matrix(wls, downsampled_wls, R; window_size=5) * flux
-
 
     # normalized?
     @test sum(flux) ≈ sum(convF)  rtol=1e-3
@@ -260,9 +259,9 @@ end
     @test sum(flux) ≈ sum(convF_mat5) rtol=1e-3
     @test sum(flux) ≈ sum(convF_mat5) rtol=1e-3
     @test sum(flux) ≈ sum(convF_mat_vec) rtol=1e-3
-    @test sum(flux) * step(wls) ≈ sum(convF_mat_downsample) * step(downsampled_wls) rtol=1e-3
     @test sum(flux) ≈ sum(convF_changing_R) rtol=1e-3
     @test sum(flux) ≈ sum(convF_mat_changing_R) rtol=1e-3
+    @test sum(flux) * step(wls) ≈ sum(convF_mat_downsample) * step(downsampled_wls) rtol=1e-3
 
     # preserves line center?
     @test argmax(convF) == spike_ind


### PR DESCRIPTION
Does what it says in the title.  So far, I haven't changed the API at all, you just pass `R` as a function rather than a constant.  But I will have to deprecate `constant_R_LSF` because the name is now wrong.