### PR TITLE
properly support [alpha/H] as a fitting parameter

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -28,6 +28,7 @@ const tan_scale_params = Dict(
     "Teff" => (2800, 8000),
     "logg" => (-0.5, 5.5),
     "m_H" => (-2.5, 1),
+    "alpha_H" => (-2.5, 1), # this isn't precisely right, because the atmospheres use alpha_M
     map(Korg.atomic_symbols) do el
         el => (-10, +4)
     end...
@@ -92,7 +93,7 @@ these can be specified in either initial_guesses or fixed_params, but if they ar
 function validate_params(initial_guesses::Dict, fixed_params::Dict;
                          required_params = ["Teff", "logg"],
                          default_params = Dict("m_H"=>0.0, "vsini"=>0.0, "vmic"=>1.0, "epsilon"=>0.6),
-                         allowed_params = Set([required_params ; keys(default_params)... ; Korg.atomic_symbols]))
+                         allowed_params = Set(["alpha_H" ; required_params ; keys(default_params)... ; Korg.atomic_symbols]))
     # convert all parameter values to Float64
     initial_guesses = Dict(string(p[1]) => Float64(p[2]) for p in pairs(initial_guesses))
     fixed_params = Dict(string(p[1]) => Float64(p[2]) for p in pairs(fixed_params))

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -28,7 +28,9 @@ const tan_scale_params = Dict(
     "Teff" => (2800, 8000),
     "logg" => (-0.5, 5.5),
     "m_H" => (-2.5, 1),
-    "alpha_H" => (-2.5, 1), # this isn't precisely right, because the atmospheres use alpha_M
+    # this allows all the atmospheres supported by the grid, but also many that are not.
+    # alpha will be clamped to the nearest supported value.
+    "alpha_H" => (-3.5, 2), 
     map(Korg.atomic_symbols) do el
         el => (-10, +4)
     end...
@@ -167,7 +169,9 @@ Single-element NamedTuples require a semicolon: `(; Teff=5000)`.
 These can be specified in either `initial_guesses` or `fixed_params`, but if they are not default 
 values are used.
 - `m_H`: the metallicity of the star, in dex. Default: `0.0`
-- `alpha_H`: the alpha enhancement of the star, in dex. Default: `m_H`.
+- `alpha_H`: the alpha enhancement of the star, in dex. Default: `m_H`.  Note that, because of the 
+  parameter range supported by [`Korg.interpolate_marcs`](@ref), only values within ±1 of `m_H` 
+  are supported.
 - `vmic`: the microturbulence velocity, in km/s. Default: `1.0`
 - `vsini`: the projected rotational velocity of the star, in km/s. Default: `0.0`. 
    See [`Korg.apply_rotation`](@ref) for details.

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -11,6 +11,14 @@
         @test_throws ArgumentError Korg.Fit.validate_params((; logg = 3200), (;))
         @test_throws ArgumentError Korg.Fit.validate_params((Teff=4500, logg = 3200, m_H = 0.1), (; m_H=0.1))
 
+        # alpha may be specified, but it has no default, making it a special case
+        p0, _ = Korg.Fit.validate_params((Teff=4500, logg=4.5, alpha_H=0.2), (;))
+        @test p0["alpha_H"] == 0.2
+        _, fixed = Korg.Fit.validate_params((Teff=4500, logg=4.5), (; alpha_H=0.2))
+        @test fixed["alpha_H"] == 0.2
+        p0, fixed = Korg.Fit.validate_params((Teff=4500, logg=4.5), (;))
+        @test !("alpha_H" in keys(p0)) && !("alpha_H" in keys(fixed))
+
         for initial_guess in [(Teff=4500, logg=4.5), Dict("Teff"=> 4500, "logg"=>4.5)]
             for fixed_params in [(;), Dict()]
                 _, fixed_params = Korg.Fit.validate_params(initial_guess, fixed_params)


### PR DESCRIPTION
There was vestigial partial support for this already, and the docstring claimed that it was there (though the paper doesn't).  This adds it as a fully-supported fitting param.