### PR TITLE
interpolate_marcs autodiff fix

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -299,9 +299,13 @@ function interpolate_marcs(Teff, logg, M_H=0, alpha_M=0, C_M=0; spherical=logg <
     if perturb_at_grid_values
         # add small offset to each parameter which is exactly at grid value
         # this prevents the derivatives from being exactly zero
-        params .+= 1e-30 .* (in.(params, nodes))
+        on_grid_mask = in.(params, nodes)
+        params[on_grid_mask] .= nextfloat.(params[on_grid_mask])
+
         # take care of the case where the parameter is at the last grid value
-        params .-= 2e-30 .* (params .> last.(nodes))
+        too_high_mask = params .> last.(nodes)
+        params[too_high_mask] .= prevfloat.(params[too_high_mask])
+        params[too_high_mask] .= prevfloat.(params[too_high_mask])
     end
     
     upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)


### PR DESCRIPTION
When atmospheric params are on grid values, we perturb them away to avoid null derivatives.  This PR makes sure that the perturbations are never too small for the floating point type to handle.