### PR TITLE
calculate the formal parameter error when using BFGS

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -208,7 +208,13 @@ A NamedTuple with the following fields:
   in the `windows`)
 - `solver_result`: the result object from `Optim.jl`
 - `trace`: a vector of NamedTuples, each of which contains the parameters at each step of the 
-  optimization.
+  optimization. This is empty for single parameter fits, because the underlying solver doesn't 
+  supply it.
+- `covariance`: a pair `(params, Σ)` where `params` is vector of parameter name (providing an 
+  order), and `Σ` is an estimate of the covariance matrix of the parameters.  It is the approximate 
+  inverse hessian of the log likelihood at the best-fit parameter calculated by the BGFS algorithm, 
+  and should be interpretted with caution. For single-parameter fits (which are done with 
+  Nelder-Mead), this is not provided.
 
 !!! tip
     The function takes a long time to compile the first time it is called. Compilation performance 
@@ -262,18 +268,33 @@ function fit_spectrum(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fix
         end
     end 
     
-    res = if length(p0) == 1
+    res, invH = if length(p0) == 1
         # if we are fitting a single parameter, experimentation shows that Nelder-Mead (the default)
         # is faster than BFGS
 
         # there seems to be a problem with trace storage for this optimizer, so we don't request it
         # the precision keyword is also ignored
-        optimize(chi2, p0, Optim.Options(x_tol=precision); autodiff=:forward) 
+        optimize(chi2, p0, Optim.Options(x_tol=precision); autodiff=:forward), nothing
     else
         # if we are fitting a multiple parameters, use BFGS with autodiff
-        optimize(chi2, p0, BFGS(linesearch=LineSearches.BackTracking()),
+        res = optimize(chi2, p0, BFGS(linesearch=LineSearches.BackTracking()),
                  Optim.Options(x_tol=precision, time_limit=10_000, store_trace=true, 
                                extended_trace=true); autodiff=:forward)
+
+        # derivate relating the scaled parameters to the unscaled parameters
+        # (used to convert the approximate hessian to a covariance matrix in the unscaled params)
+        dp_dscaledp = map(res.minimizer, params_to_fit) do scaled_param, param_name
+            ForwardDiff.derivative(scaled_param) do scaled_param
+                unscale(Dict(param_name=>scaled_param))[param_name]
+            end
+        end
+        # the fact that the scaling is a diagonal operation means that we can do this as an element-wise
+        # product.  If we think of ds/dp as a (diagonal) matrix, this is equivalent to
+        # (ds/dp)^T * invH * (ds/dp)
+        invH_scaled = res.trace[end].metadata["~inv(H)"]
+        invH = invH_scaled .* dp_dscaledp .* dp_dscaledp'
+
+        res, invH
     end
     solution = unscale(Dict(params_to_fit .=> res.minimizer))
 
@@ -291,7 +312,7 @@ function fit_spectrum(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fix
     end
 
     (best_fit_params=solution, best_fit_flux=best_fit_flux, obs_wl_mask=obs_wl_mask, 
-     solver_result=res, trace=trace)
+     solver_result=res, trace=trace, covariance=(params_to_fit, invH))
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,6 +5,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -49,15 +49,14 @@ using Random
     end
 
     @testset "fit_spectrum" begin
-        
         # fit params
-        Teff = 5402.0
-        m_H = -0.02
-        vmic = 0.83
+        Teff = 6402.0
+        m_H = -1.02
 
         # fixed_params
         alpha_H = 0.1
         logg = 4.52
+        vmic = 0.83
 
         synth_wls = 5000:0.01:5010
         obs_wls = 5003 : 0.03 : 5008
@@ -75,16 +74,14 @@ using Random
         spectrum .+= randn(rng, length(spectrum)) .* err
 
         # now fit it
-        p0 = (Teff=5350.0, m_H=0.0, vmic=1.0)
-        fixed = (alpha_H=alpha_H, logg=logg)
+        p0 = (Teff=5350.0, m_H=0.0)
+        fixed = (alpha_H=alpha_H, logg=logg, vmic=vmic)
         result = Korg.Fit.fit_spectrum(obs_wls, spectrum, err, linelist, p0, fixed; 
                                        synthesis_wls=synth_wls, LSF_matrix=LSF)
         
-        @test result.best_fit_params["Teff"] ≈ Teff rtol=0.01
-        @test result.best_fit_params["m_H"] ≈ m_H rtol=0.01
-        @test result.best_fit_params["vmic"] ≈ vmic rtol=0.01
-
-        @test assert_allclose(spectrum, result.best_fit_spectrum, rtol=0.03)
+        @test result.best_fit_params["Teff"] ≈ Teff atol=150
+        @test result.best_fit_params["m_H"] ≈ m_H atol=0.05
+        @test assert_allclose(spectrum, result.best_fit_flux, rtol=0.05)
     end
 
     @testset "don't allow hydrogen lines in ew_to_abundances" begin

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -68,9 +68,7 @@ using Random
         atm = interpolate_marcs(Teff, logg, m_H)
         sol = synthesize(atm, linelist, format_A_X(m_H), [synth_wls]; vmic=vmic)
         spectrum = LSF * (sol.flux ./ sol.cntm)
-        err = 0.01 * ones(length(spectrum))
-        rng = MersenneTwister(1234)
-        spectrum .+= randn(rng, length(spectrum)) .* err
+        err = 0.01 * ones(length(spectrum)) # don't actually apply error to keep tests deterministic
 
         # now fit it
         p0 = (Teff=5350.0, m_H=0.0)
@@ -85,11 +83,11 @@ using Random
         m_H_sigma = sqrt(Σ[m_H_index, m_H_index])
         
         # check that inferred parameters are within 2 sigma of the true values
-        @test result.best_fit_params["Teff"] ≈ Teff atol=2Teff_sigma
-        @test result.best_fit_params["m_H"] ≈ m_H atol=2m_H_sigma
+        @test result.best_fit_params["Teff"] ≈ Teff atol=1Teff_sigma
+        @test result.best_fit_params["m_H"] ≈ m_H atol=1m_H_sigma
 
         # check that best-fit flux is within 5% (5 σ) of the true flux at all pixels
-        @test assert_allclose(spectrum, result.best_fit_flux, rtol=0.05)
+        @test assert_allclose(spectrum, result.best_fit_flux, rtol=0.01)
     end
 
     @testset "don't allow hydrogen lines in ew_to_abundances" begin

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -54,7 +54,6 @@ using Random
         m_H = -1.02
 
         # fixed_params
-        alpha_H = 0.1
         logg = 4.52
         vmic = 0.83
 
@@ -66,8 +65,8 @@ using Random
         LSF = Korg.compute_LSF_matrix(synth_wls, obs_wls, 50_000; verbose=false)
 
         # generate a spectrum and 
-        atm = interpolate_marcs(Teff, logg, m_H, alpha_H)
-        sol = synthesize(atm, linelist, format_A_X(m_H, alpha_H), [synth_wls]; vmic=vmic)
+        atm = interpolate_marcs(Teff, logg, m_H)
+        sol = synthesize(atm, linelist, format_A_X(m_H), [synth_wls]; vmic=vmic)
         spectrum = LSF * (sol.flux ./ sol.cntm)
         err = 0.01 * ones(length(spectrum))
         rng = MersenneTwister(1234)
@@ -75,7 +74,7 @@ using Random
 
         # now fit it
         p0 = (Teff=5350.0, m_H=0.0)
-        fixed = (alpha_H=alpha_H, logg=logg, vmic=vmic)
+        fixed = (logg=logg, vmic=vmic)
         result = Korg.Fit.fit_spectrum(obs_wls, spectrum, err, linelist, p0, fixed; 
                                        synthesis_wls=synth_wls, LSF_matrix=LSF)
         

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,11 +175,11 @@ end
             A_X = format_A_X(m_H, alpha_H, Dict("C"=>C_H); solar_abundances=Korg.grevesse_2007_solar_abundances)
             atm2 = interpolate_marcs(teff, logg, A_X)
 
-            @test assert_allclose(Korg.get_tau_5000s(atm1), Korg.get_tau_5000s(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_zs(atm1), Korg.get_zs(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_temps(atm1), Korg.get_temps(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_electron_number_densities(atm1), Korg.get_electron_number_densities(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_number_densities(atm1), Korg.get_number_densities(atm2); rtol=1e-3)
+            @test assert_allclose(Korg.get_tau_5000s(atm1), Korg.get_tau_5000s(atm2); rtol=1e-6)
+            @test assert_allclose(Korg.get_zs(atm1), Korg.get_zs(atm2); rtol=1e-6)
+            @test assert_allclose(Korg.get_temps(atm1), Korg.get_temps(atm2); rtol=1e-7)
+            @test assert_allclose(Korg.get_electron_number_densities(atm1), Korg.get_electron_number_densities(atm2); rtol=1e-6)
+            @test assert_allclose(Korg.get_number_densities(atm1), Korg.get_number_densities(atm2); rtol=1e-6)
         end
 
         @testset "grid points" begin


### PR DESCRIPTION
`fit_spectrum` uses BFGS for multi-parameter fits.  This PR takes the estimated inverse hessian of the likelihood that BFGS provides, and transforms it to unscaled parameters so that it can be used as an estimate of the error covariance matrix.

TODO
- [x] add test (after #252 is merged)