### PR TITLE
fix bug; add and refactor tests

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -207,7 +207,7 @@ function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real};
     C_H = A_X[6] - solar_abundances[6]
     C_M = C_H - M_H
     if clamp_abundances
-        nodes = _sdss_marcs_atmospheres
+        nodes = _sdss_marcs_atmospheres[1]
         M_H = clamp(M_H, nodes[3][1], nodes[3][end])
         alpha_M = clamp(C_M, nodes[4][1], nodes[4][end])
         C_M = clamp(C_M, nodes[5][1], nodes[5][end])

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -1,0 +1,96 @@
+@testset "atmosphere" begin
+    function assert_atmospheres_close(atm1, atm2; rtol=1e-3)
+        val = true
+        for f in [Korg.get_tau_5000s, Korg.get_zs, Korg.get_temps, Korg.get_number_densities, Korg.get_electron_number_densities]
+            val &= assert_allclose(f(atm1), f(atm2); rtol=rtol, print_rachet_info=false)
+        end
+        val
+    end
+
+    @testset "plane-parallel atmosphere" begin
+        #the MARCS solar model atmosphere
+        atm = Korg.read_model_atmosphere("data/sun.mod")
+        @test atm isa Korg.PlanarAtmosphere
+        @test length(atm.layers) == 56
+        @test issorted([l.temp for l in atm.layers])
+        @test atm.layers[1].tau_5000 ≈ 0.00001209483645
+        @test atm.layers[1].z == 6.931E+07
+        @test atm.layers[1].temp == 4066.8
+        @test atm.layers[1].electron_number_density ≈ 3.769664452210607e10
+        @test atm.layers[1].number_density ≈ 4.75509171357701e14
+
+        # just make sure these don't error
+        Korg.get_tau_5000s(atm)
+        Korg.get_zs(atm)
+        Korg.get_temps(atm)
+        Korg.get_electron_number_densities(atm)
+        Korg.get_number_densities(atm)
+    end
+    @testset "spherical atmosphere" begin
+        atm = Korg.read_model_atmosphere(
+                "data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
+        @test atm isa Korg.ShellAtmosphere
+        @test length(atm.layers) == 56 
+        @test issorted([l.temp for l in atm.layers])
+        @test atm.R == 2.5827E+12
+        @test atm.layers[1].tau_5000 ≈ 4.584584692493259e-5
+        @test atm.layers[1].z == 2.222e11
+        @test atm.layers[1].temp == 3935.2
+        @test atm.layers[1].electron_number_density ≈ 1.7336231777439526e8
+        @test atm.layers[1].number_density ≈ 1.5411190391302566e12
+    end
+
+    @testset "atmosphere type conversion" begin
+        atm = Korg.read_model_atmosphere("data/sun.mod")
+        atm2 = Korg.PlanarAtmosphere(Korg.ShellAtmosphere(atm, 7e10)) #arbitrary radius
+        @test atm.layers == atm2.layers
+
+        atm = Korg.read_model_atmosphere(
+                "data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
+        atm2 = Korg.ShellAtmosphere(Korg.PlanarAtmosphere(atm), 1.0)
+        @test [l.tau_5000 for l in atm.layers]                == [l.tau_5000 for l in atm2.layers]
+        @test [l.z for l in atm.layers]                       == [l.z for l in atm2.layers]
+        @test [l.temp for l in atm.layers]                    == [l.temp for l in atm2.layers]
+        @test [l.number_density for l in atm.layers]          == [l.number_density for l in atm2.layers]
+        @test [l.electron_number_density for l in atm.layers] == [l.electron_number_density for l in atm2.layers]
+    end
+
+
+    @testset "model atmosphere interpolation" begin
+        @testset "methods are equivalent" begin
+            teff = 5000.0
+            logg = 4.0
+            m_H = 0.1
+            alpha_H = 0.2
+            C_H = 0.3
+            atm1 = interpolate_marcs(teff, logg, m_H, alpha_H - m_H, C_H - m_H)
+            A_X = format_A_X(m_H, alpha_H, Dict("C"=>C_H); solar_abundances=Korg.grevesse_2007_solar_abundances)
+            atm2 = interpolate_marcs(teff, logg, A_X)
+
+            @test assert_atmospheres_close(atm1, atm2; rtol=1e-5)
+        end
+
+        @testset "clamping abundances" begin
+            m_H_nodes = Korg._sdss_marcs_atmospheres[1][3]
+
+            atm1 = interpolate_marcs(5000.0, 3.0, m_H_nodes[1])
+            A_X_2 = format_A_X(m_H_nodes[1] - 1; solar_abundances=Korg.grevesse_2007_solar_abundances)
+            atm2 = interpolate_marcs(5000.0, 3.0, A_X_2; clamp_abundances=true)
+            @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
+
+            atm1 = interpolate_marcs(5000.0, 3.0, m_H_nodes[end])
+            A_X_2 = format_A_X(m_H_nodes[end] + 1; solar_abundances=Korg.grevesse_2007_solar_abundances)
+            atm2 = interpolate_marcs(5000.0, 3.0, A_X_2; clamp_abundances=true)
+            @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
+        end
+
+        @testset "grid points" begin
+            # calling the interpolator on grid points should return the same atmosphere
+            atm1 = Korg.read_model_atmosphere("data/s5000_g+3.0_m1.0_t02_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
+            atm2 = Korg.interpolate_marcs(5000, 3.0)
+
+            # values are not precisely identical.  I think this is due to slightly different solar mixtures.
+            @test assert_atmospheres_close(atm1, atm2; rtol=2e-3)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("linelist.jl")
 include("fit.jl")
 include("autodiff.jl")
 include("autodiffable_conv.jl")
+include("atmosphere.jl")
 
 @testset "atomic data" begin 
     @test (Korg.MAX_ATOMIC_NUMBER 
@@ -114,88 +115,6 @@ end
     end
 end
 
-@testset "atmosphere" begin
-    @testset "plane-parallel atmosphere" begin
-        #the MARCS solar model atmosphere
-        atm = Korg.read_model_atmosphere("data/sun.mod")
-        @test atm isa Korg.PlanarAtmosphere
-        @test length(atm.layers) == 56
-        @test issorted([l.temp for l in atm.layers])
-        @test atm.layers[1].tau_5000 ≈ 0.00001209483645
-        @test atm.layers[1].z == 6.931E+07
-        @test atm.layers[1].temp == 4066.8
-        @test atm.layers[1].electron_number_density ≈ 3.769664452210607e10
-        @test atm.layers[1].number_density ≈ 4.75509171357701e14
-
-        # just make sure these don't error
-        Korg.get_tau_5000s(atm)
-        Korg.get_zs(atm)
-        Korg.get_temps(atm)
-        Korg.get_electron_number_densities(atm)
-        Korg.get_number_densities(atm)
-    end
-    @testset "spherical atmosphere" begin
-        atm = Korg.read_model_atmosphere(
-                "data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
-        @test atm isa Korg.ShellAtmosphere
-        @test length(atm.layers) == 56 
-        @test issorted([l.temp for l in atm.layers])
-        @test atm.R == 2.5827E+12
-        @test atm.layers[1].tau_5000 ≈ 4.584584692493259e-5
-        @test atm.layers[1].z == 2.222e11
-        @test atm.layers[1].temp == 3935.2
-        @test atm.layers[1].electron_number_density ≈ 1.7336231777439526e8
-        @test atm.layers[1].number_density ≈ 1.5411190391302566e12
-    end
-
-    @testset "atmosphere type conversion" begin
-        atm = Korg.read_model_atmosphere("data/sun.mod")
-        atm2 = Korg.PlanarAtmosphere(Korg.ShellAtmosphere(atm, 7e10)) #arbitrary radius
-        @test atm.layers == atm2.layers
-
-        atm = Korg.read_model_atmosphere(
-                "data/s6000_g+1.0_m0.5_t05_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
-        atm2 = Korg.ShellAtmosphere(Korg.PlanarAtmosphere(atm), 1.0)
-        @test [l.tau_5000 for l in atm.layers]                == [l.tau_5000 for l in atm2.layers]
-        @test [l.z for l in atm.layers]                       == [l.z for l in atm2.layers]
-        @test [l.temp for l in atm.layers]                    == [l.temp for l in atm2.layers]
-        @test [l.number_density for l in atm.layers]          == [l.number_density for l in atm2.layers]
-        @test [l.electron_number_density for l in atm.layers] == [l.electron_number_density for l in atm2.layers]
-    end
-
-
-    @testset "model atmosphere interpolation" begin
-        @testset "methods are equivalent" begin
-            teff = 5000.0
-            logg = 4.0
-            m_H = 0.1
-            alpha_H = 0.2
-            C_H = 0.3
-            atm1 = interpolate_marcs(teff, logg, m_H, alpha_H - m_H, C_H - m_H)
-            A_X = format_A_X(m_H, alpha_H, Dict("C"=>C_H); solar_abundances=Korg.grevesse_2007_solar_abundances)
-            atm2 = interpolate_marcs(teff, logg, A_X)
-
-            @test assert_allclose(Korg.get_tau_5000s(atm1), Korg.get_tau_5000s(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_zs(atm1), Korg.get_zs(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_temps(atm1), Korg.get_temps(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_electron_number_densities(atm1), Korg.get_electron_number_densities(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_number_densities(atm1), Korg.get_number_densities(atm2); rtol=1e-3)
-        end
-
-        @testset "grid points" begin
-            # calling the interpolator on grid points should return the same atmosphere
-            atm1 = Korg.read_model_atmosphere("data/s5000_g+3.0_m1.0_t02_st_z+0.00_a+0.00_c+0.00_n+0.00_o+0.00_r+0.00_s+0.00.mod")
-            atm2 = Korg.interpolate_marcs(5000, 3.0)
-
-            # values are not precisely identical.  I think this is due to slightly different solar mixtures.
-            @test assert_allclose(Korg.get_tau_5000s(atm1), Korg.get_tau_5000s(atm2); rtol=2e-3)
-            @test assert_allclose(Korg.get_zs(atm1), Korg.get_zs(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_temps(atm1), Korg.get_temps(atm2); rtol=2e-4)
-            @test assert_allclose(Korg.get_electron_number_densities(atm1), Korg.get_electron_number_densities(atm2); rtol=1e-3)
-            @test assert_allclose(Korg.get_number_densities(atm1), Korg.get_number_densities(atm2); rtol=2e-4)
-        end
-    end
-end
 
 @testset "synthesis" begin
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -18,7 +18,7 @@ shape, the locations of the max errors are also printed.
 - `error_location_fmt`: An optional keyword used to specify a function that creates a string 
   describing the location in the arrays where values are unequal, given a `CartesianIndex` object.
   This should not be specified in cases where actual and reference have different shapes.
-- `print_racheting_info`: set this to false to avoid printing a notice and stacktrace with rtol
+- `print_rachet_info`: set this to false to avoid printing a notice and stacktrace with rtol
   or atol can be tightened.
 
 """


### PR DESCRIPTION
Embarrassingly, #255 wasn't the only bug carelessly introduced by #252.

This addresses another one, adds a test that would have caught it, and refactors the atmosphere testing code generally.  There's now a function to facilitate testing approximate equality of model atmospheres, and atmosphere tests have been factored into a separate file.