### PR TITLE
Retry chemical equilibrium solver with very small initial $n_e$ if it fails to converge

### DIFF
--- a/src/statmech.jl
+++ b/src/statmech.jl
@@ -175,7 +175,14 @@ function _solve_chemical_equilibrium(temp, nₜ, absolute_abundances, neutral_fr
     sol = try
         nlsolve(residuals!, x0; method=:newton, iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
     catch e
-        throw(ChemicalEquilibriumError("solver failed: $e"))
+        try 
+            # try again with the nₑ guess set to be very small.  Much smaller than this and we start
+            # to get noninvertible matrices in the solver
+            x0[end] = 1e-5 
+            nlsolve(residuals!, x0; method=:newton, iterations=1_000, store_trace=true, ftol=1e-8, autodiff=:forward)
+        catch e
+            throw(ChemicalEquilibriumError("solver failed: $e"))
+        end
     end
 
     if !sol.f_converged


### PR DESCRIPTION
I noticed while working on model atmosphere inversion that the Korg solver almost always converges if I start it with a very low $n_e$.  In this PR, I start the solver over with an initial guess of $n_e = n_\mathrm{tot} \times 10^{-10}$ if it failed the first time.  This change gets Korg to convergence for all parameters tried in #129.