### PR TITLE
remove H lines from built-in galah linelist

### DIFF
--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -36,9 +36,12 @@ function line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_
     β = @. 1/(kboltz_eV * temp)
 
     # precompute number density / partition function for each species in the linelist
-    n_div_Z = map(collect(Set([l.species for l in linelist]))) do spec
+    n_div_Z = map(unique([l.species for l in linelist])) do spec
         spec => @. (n_densities[spec] / partition_fns[spec](log(temp)))
     end |> Dict
+    if species"H I" in keys(n_div_Z)
+        @error "Atomic hydrogen should not be in the linelist. Korg has built-in hydrogen lines."
+    end
 
     for line in linelist
         m = get_mass(line.species)

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -584,7 +584,7 @@ function get_GALAH_DR3_linelist()
             end
             Species(formula, ion-1)
         end
-        Line.(
+        lines = Line.(
             Float64.(read(f["wl"])),
             Float64.(read(f["log_gf"])),
             species,
@@ -593,5 +593,9 @@ function get_GALAH_DR3_linelist()
             tentotheOrMissing.(Float64.(read(f["gamma_stark"]))),
             idOrMissing.(Float64.(read(f["vdW"])))
         )
+        filter!(lines) do line
+            #take out the hydrogen lines
+            line.species != species"H I"
+        end
     end
 end


### PR DESCRIPTION
Also add a check to throw an error if there are any H lines in the linelist when you try to synthesize.  (Should have done this long ago.)

![image](https://github.com/ajwheeler/Korg.jl/assets/711963/cbbc8b9b-db7c-451e-ba54-8a11280927bd)

