### PR TITLE
Reduce memory footprint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]

--- a/src/hydrogen_line_absorption.jl
+++ b/src/hydrogen_line_absorption.jl
@@ -74,9 +74,8 @@ Keyword arguments:
 - `use_MHD`: whether or not to use the Mihalas-Daeppen-Hummer formalism to adjust the occupation 
    probabilities of each hydrogen orbital for plasma effects.  Default: `true`.
 """
-function hydrogen_line_absorption!(αs, wl_ranges, T, nₑ, nH_I, nHe_I, UH_I, ξ, window_size; 
+function hydrogen_line_absorption!(αs, λs, wl_ranges, T, nₑ, nH_I, nHe_I, UH_I, ξ, window_size; 
                                    stark_profiles=_hline_stark_profiles, use_MHD=true)
-    λs = vcat(collect.(wl_ranges)...)
     νs = c_cgs ./ λs
     dνdλ = c_cgs ./ λs.^2
     Hmass = get_mass(Formula("H"))
@@ -143,6 +142,7 @@ function hydrogen_line_absorption!(αs, wl_ranges, T, nₑ, nH_I, nHe_I, UH_I, �
         dIdν = exp.(line.profile.(T, nₑ, log.(scaled_Δν)))
         @inbounds view(αs, lb:ub) .+= dIdν .* view(dνdλ, lb:ub) .* amplitude
     end
+
     # now do the Brackett series
     n = 4
     E_low = RydbergH_eV * (1 - 1/n^2)
@@ -157,9 +157,8 @@ function hydrogen_line_absorption!(αs, wl_ranges, T, nₑ, nH_I, nHe_I, UH_I, �
         lb, ub = move_bounds(wl_ranges, 0, 0, λ0, stark_window)
 
         # renormalize profile?
-        @inbounds view(αs, lb:ub) .+= stark_profile_itp.(view(λs, lb:ub)) .* amplitude
+        view(αs, lb:ub) .+= stark_profile_itp.(view(λs, lb:ub)) .* amplitude
     end
-
 end
 
 """

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -49,7 +49,6 @@ function line_absorption!(α, linelist, λs, temps::V, nₑ, n_densities, partit
     end
 
     # preallocate some arrays for the core loop. 
-    # The compiler is smart enough to preallocate the scalars
     # Each element of the arrays corresponds to an atmospheric layer, same at the "temps" array and 
     # the values in "number_densities"
     Γ = Vector{eltype(α)}(undef, size(temps))

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -22,8 +22,9 @@ other arguments:
 - `cuttoff_threshold` (default: 3e-4): see `α_cntm`
 - `verbose` (default: false): if true, show a progress bar.
 """
-function line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_fns, ξ, 
-                          α_cntm; cutoff_threshold=3e-4, verbose=false)
+function line_absorption!(α, linelist, λs, temps::V, nₑ, n_densities, partition_fns, ξ, 
+                          α_cntm; cutoff_threshold=3e-4, verbose=false
+                          ) where V <: AbstractVector{<:Real} #TODO needed?
 
     if length(linelist) == 0
         return zeros(length(λs))
@@ -37,45 +38,59 @@ function line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_
     #and longest wavelengths which feel the effect of each line 
     lb = 1
     ub = 1
-    β = @. 1/(kboltz_eV * temp)
+    β = @. 1/(kboltz_eV * temps)
 
     # precompute number density / partition function for each species in the linelist
     n_div_Z = map(unique([l.species for l in linelist])) do spec
-        spec => @. (n_densities[spec] / partition_fns[spec](log(temp)))
+        spec => @. (n_densities[spec] / partition_fns[spec](log(temps)))
     end |> Dict
     if species"H I" in keys(n_div_Z)
         @error "Atomic hydrogen should not be in the linelist. Korg has built-in hydrogen lines."
     end
 
+    # preallocate some arrays for the core loop. 
+    # The compiler is smart enough to preallocate the scalars
+    # Each element of the arrays corresponds to an atmospheric layer, same at the "temps" array and 
+    # the values in "number_densities"
+    Γ = Vector{eltype(α)}(undef, size(temps))
+    γ = Vector{eltype(α)}(undef, size(temps))
+    σ = Vector{eltype(α)}(undef, size(temps))
+    amplitude = Vector{eltype(α)}(undef, size(temps))
+    levels_factor = Vector{eltype(α)}(undef, size(temps))
+    ρ_crit = Vector{eltype(α)}(undef, size(temps))
+    inverse_densities = Vector{eltype(α)}(undef, size(temps))
     @showprogress desc="calculating line opacities" enabled=verbose for line in linelist
         m = get_mass(line.species)
         
         # doppler-broadening width, σ (NOT √[2]σ)
-        σ = doppler_width.(line.wl, temp, m, ξ)
+        σ .= doppler_width.(line.wl, temps, m, ξ)
 
         # sum up the damping parameters.  These are FWHM (γ is usually the Lorentz HWHM) values in 
         # angular, not cyclical frequency (ω, not ν).
-        Γ = line.gamma_rad 
+        Γ .= line.gamma_rad 
         if !ismolecule(line.species) 
-            Γ = Γ .+ (nₑ .* scaled_stark.(line.gamma_stark, temp) +
-                      n_densities[species"H_I"] .* scaled_vdW.(Ref(line.vdW), m, temp))
+            @. Γ += nₑ * scaled_stark.(line.gamma_stark, temps) 
+            Γ .+= n_densities[species"H_I"] .* scaled_vdW.(Ref(line.vdW), m, temps)
         end
         # calculate the lorentz broadening parameter in wavelength. Doing this involves an 
         # implicit aproximation that λ(ν) is linear over the line window.
         # the factor of λ²/c is |dλ/dν|, the factor of 1/2π is for angular vs cyclical freqency,
         # and the last factor of 1/2 is for FWHM vs HWHM
-        γ = @. Γ * line.wl^2 / (c_cgs * 4π)
+        @. γ = Γ * line.wl^2 / (c_cgs * 4π)
 
         E_upper = line.E_lower + c_cgs * hplanck_eV / line.wl 
-        levels_factor = (@. (exp(-β*line.E_lower) - exp(-β*E_upper)))
+        @. levels_factor = exp(-β*line.E_lower) - exp(-β*E_upper)
 
         #total wl-integrated absorption coefficient
-        amplitude = @. 10.0^line.log_gf*sigma_line(line.wl)*levels_factor*n_div_Z[line.species]
+        @. amplitude = 10.0^line.log_gf*sigma_line(line.wl)*levels_factor*n_div_Z[line.species]
 
-        ρ_crit = [cntm(line.wl) * cutoff_threshold for cntm in α_cntm] ./ amplitude
-        doppler_line_window = maximum(inverse_gaussian_density.(ρ_crit, σ))
-        lorentz_line_window = maximum(inverse_lorentz_density.(ρ_crit, γ))
+        ρ_crit .= (line.wl .|> α_cntm) .* cutoff_threshold ./ amplitude
+        inverse_densities .= inverse_gaussian_density.(ρ_crit, σ)
+        doppler_line_window = maximum(inverse_densities)
+        inverse_densities .= inverse_lorentz_density.(ρ_crit, γ)
+        lorentz_line_window = maximum(inverse_densities)
         window_size = sqrt(lorentz_line_window^2 + doppler_line_window^2)
+        # at present, this line is allocating. Would be good to fix that.
         lb, ub = move_bounds(λs, lb, ub, line.wl, window_size)
         if lb > ub
             continue

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -1,4 +1,4 @@
-using Interpolations: GriddedInterpolation, interpolate, Gridded, NoInterp, Linear
+using Interpolations: GriddedInterpolation, interpolate!, Gridded, NoInterp, Linear
 using HDF5
 
 struct MolecularCrossSection
@@ -82,11 +82,13 @@ function interpolate_molecular_cross_sections!(α::Matrix{R}, molecular_cross_se
         return
     end
 
-    α_mol = zeros(R, size(α))
     for sigma in molecular_cross_sections
-        α_mol .+= sigma.itp.(vmic, log10.(Ts), (1:size(α, 2))') .* number_densities[sigma.species]
+        for i in size(α, 1)
+            # this is an inefficient order in which to write to α, but doing the interpolations this
+            # way uses significantly less memory.
+            α[i, :] .+= sigma.itp(vmic, log10(Ts[i]), 1:size(α, 2)) * number_densities[sigma.species][i]
+        end
     end
-    α .+= α_mol
     ;
 end
 
@@ -127,9 +129,9 @@ function read_molecular_cross_section(filename)
         alpha_vals = HDF5.read(file, "vals")
         species = Species(HDF5.read(file, "species"))
 
-        itp = interpolate((vmic_vals, T_vals, 1:sum(length.(wls))),
-                          alpha_vals,
-                          (Gridded(Linear()), Gridded(Linear()), NoInterp()))
+        itp = interpolate!((vmic_vals, T_vals, 1:sum(length.(wls))),
+                           alpha_vals,
+                           (Gridded(Linear()), Gridded(Linear()), NoInterp()))
 
         MolecularCrossSection(wls, itp, species)
     end


### PR DESCRIPTION
Makes some tweaks to reduce the number of allocations and Korg's total memory usage. Thanks to @andrew-saydjari for pointing out TimerOutputs.jl.

Synthesizing an apogee spectrum with 0.29.0
```
@btime synthesize(atm, linelist, format_A_X(), 15_000, 17_000; molecular_cross_sections=[water_sigma]);
  3.342 s (5755993 allocations: 1.63 GiB)
```

on this branch
```
  2.895 s (4404069 allocations: 1021.93 MiB)
```

There is definitely more than can be done here, but I wanted to take care of the low-hanging fruit quickly.  It's not exactly obvious how this will translate to memory usage for grid generation or fitting, which has been unsatisfactory historically.