### PR TITLE
support for departure coefficients

### DIFF
--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -7,6 +7,7 @@ module Korg
     include("isotopic_data.jl")            # abundances and nuclear spins
     include("species.jl")                  # types for chemical formulae and species
     include("linelist.jl")                 # parse linelists, define Line type
+    include("levels.jl")                   # dealing with atomic levels
     include("line_absorption.jl")          # opacity, line profile, voigt function
     include("hydrogen_line_absorption.jl") # hydrogen lines get special treatment
     include("autodiffable_conv.jl")        # wrap DSP.conv to be autodiffable

--- a/src/levels.jl
+++ b/src/levels.jl
@@ -1,0 +1,75 @@
+#TODO wrap in module
+
+import Base: ≈, broadcastable
+
+struct Configuration
+    config::String
+end
+broadcastable(e::Configuration) = Ref(e)
+
+# electron configurations are approx equal if one is a terminal substring of the other
+function ≈(a::Configuration, b::Configuration) 
+    l = min(length(a.config), length(b.config))
+    a.config[end-l+1:end] == b.config[end-l+1:end]
+end
+
+struct Term
+    term::String
+end
+broadcastable(t::Term) = Ref(t)
+function simplify(t::Term)
+    t = t.term
+    if (length(t) > 0) && islowercase(t[1])
+        t = t[2:end]
+    end
+    if (length(t) > 0) && isdigit(t[end])
+        t = t[1:end-1]
+    end
+    Term(t)
+end
+function ≈(a::Term, b::Term)
+    simplify(a) == simplify(b)
+end
+
+struct AtomicLevel
+    config::Configuration
+    term::Term
+    g::UInt8 # 2J + 1
+    energy::Float64
+end
+broadcastable(l::AtomicLevel) = Ref(l)
+function Base.show(io::IO, ::MIME"text/plain", level::AtomicLevel)
+    print(io, level.config.config, " ", level.term.term, " g=", level.g, " E=", level.energy, "eV")
+end
+
+"""
+TODO
+"""
+function match_levels(linelist_levels, model_levels; energy_difference_threshold=0.05)
+    map(linelist_levels) do level
+        configs_match = [level.config ≈ m.config for m in model_levels]
+        terms_match = [level.term == m.term for m in model_levels]
+        terms_approx_match = [level.term ≈ m.term for m in model_levels]
+        gs_match = [level.g == m.g for m in model_levels]
+
+        for (i, matches) in enumerate([
+                configs_match .& terms_match .& gs_match,
+                configs_match .& terms_approx_match .& gs_match,
+                configs_match .& terms_match,
+                configs_match .& terms_approx_match,
+                terms_match,
+                terms_approx_match
+                ])
+            
+            if sum(matches) == 1
+                return i, findfirst(matches)
+            elseif sum(matches) > 1
+                ΔE = [abs(m.energy - level.energy) for m in model_levels[matches]]
+                # TODO use energy threshold
+                #@warn "$level is may correspond to any of $(sum(matches)) levels in the model atom.  Choosing closest_level (ΔE = $(minimum(ΔE)))"
+                return (i + 0.5, findfirst(ΔE .== minimum(ΔE)))
+            end
+        end
+        0, nothing
+    end
+end

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -95,7 +95,9 @@ function line_absorption!(α, linelist, λs, temps, nₑ, n_densities, partition
             b_lo = departure_coefs[:, lower_indices[line_ind]]
             b_up = departure_coefs[:, upper_indices[line_ind]]
             boltzmann_ratio = @. exp(β *  c_cgs * hplanck_eV / line.wl)
-            @. levels_factor = (b_lo * boltzmann_ratio - b_up) / (boltzmann_ratio - 1)
+
+            #TODO audit for stimulated emission
+            @. levels_factor = exp(-β*line.E_lower) * (b_lo * boltzmann_ratio - b_up) / (boltzmann_ratio - 1)
         else
             @. levels_factor = exp(-β*line.E_lower) - exp(-β*E_upper)
         end

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -157,6 +157,16 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::AbstractVector{<:Real},
             wl_range[1] - line_buffer <= line.wl <= wl_range[end]
         end |> any
     end
+    #TODO clean up filtering
+    for i in 1:length(NLTE_lines)
+        lines, bs = NLTE_lines[i]
+        lines = filter(lines) do (_, _, line)
+            map(wl_ranges) do wl_range
+                wl_range[1] - line_buffer <= line.wl <= wl_range[end]
+            end |> any
+        end
+        NLTE_lines[i] = (lines, bs)
+    end
 
     if length(A_X) != MAX_ATOMIC_NUMBER || (A_X[1] != 12)
         throw(ArgumentError("A(H) must be a 92-element vector with A[1] == 12."))


### PR DESCRIPTION
This PR implements support for departure coefficients, and includes an algorithm for matching levels from the linelist to the model atom which was suggested by Thomas Nordlander.  

TODO
- [ ] tests
- [ ] documentation
- [ ] joint atmosphere and departure coef interpolation
- [ ] custom Korg departure coef format?
- [ ] automatic downloads
- [ ] understand comparison to SME for GALAH spectra.  (Why are line depths slightly different?)
- [ ] ensure no performance regression for pure-LTE synthesis