### PR TITLE
tweaks to linelist pruning

### DIFF
--- a/test/prune_linelist.jl
+++ b/test/prune_linelist.jl
@@ -4,9 +4,11 @@
     atm = interpolate_marcs(5000, 4.44);
     A_X = format_A_X()
 
-    strong_lines_sorted = Korg.prune_linelist(atm, linelist, A_X, wls)
-    strong_lines_unsorted = Korg.prune_linelist(atm, linelist, A_X, wls; sort_by_EW=false)
-    more_strong_lines = Korg.prune_linelist(atm, linelist, A_X, wls; sort_by_EW=false, threshold=0.01)
+    strong_lines_sorted = Korg.prune_linelist(atm, linelist, A_X, wls; verbose=false)
+    strong_lines_unsorted = Korg.prune_linelist(atm, linelist, A_X, wls
+                                               ;sort_by_EW=false, verbose=false)
+    more_strong_lines = Korg.prune_linelist(atm, linelist, A_X, wls
+                                           ;sort_by_EW=false, threshold=0.01, verbose=false)
 
     @test Set(strong_lines_sorted) == Set(strong_lines_unsorted)
     @test issorted(strong_lines_unsorted; by=l->l.wl)

--- a/test/prune_linelist.jl
+++ b/test/prune_linelist.jl
@@ -11,4 +11,7 @@
     @test Set(strong_lines_sorted) == Set(strong_lines_unsorted)
     @test issorted(strong_lines_unsorted; by=l->l.wl)
     @test Set(strong_lines_sorted) ⊆ Set(more_strong_lines)
+
+    merged_lines = Korg.merge_close_lines(strong_lines_sorted)
+    @assert issorted(merged_lines; by=first)
 end


### PR DESCRIPTION
- use reduced EW instead of EW, integrate between +- 90 km/s, not 2 A. (Thanks to T. Nordlander for suggestion.)
- return wavelength extrema of each multiplet
- clarify that merged lines are wl-sorted, and test that.