### PR TITLE
add fitting params for linear adjustment to continuum

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -23,7 +23,7 @@ tan_unscale(p, lower, upper) = (atan(p)/π + 0.5)*(upper - lower) + lower
 # these are the parameters which are scaled by tan_scale
 const tan_scale_params = Dict(
     "epsilon" => (0, 1),
-    "cntm_offset" => (-0.1, 0.1),
+    "cntm_offset" => (-0.5, 0.5),
     "cntm_slope" => (-0.1, 0.1),
     # we can't get these directly from Korg.get_atmosphere_archive() because it will fail in the 
     # test environment, but they are simply the boundaries of the SDSS marcs grid used by

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -19,7 +19,7 @@ Compute a synthetic spectrum.
 - `λ_step` (default: 0.01): the (approximate) step size to take (in Å).
 
 If you provide a vector of wavelength ranges (or a single range) in place of `λ_start` and `λ_stop`, 
-the spectrum will be synthesized over each range with minimal overhead.  These can be any Julia
+the spectrum will be synthesized over each range with minimal overhead.
 The ranges can be any Julia `AbstractRange`, for example: `[5000:0.01:5010, 6000:0.03:6005]`. they
 must be sorted and non-overlapping.
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -65,6 +65,7 @@ using Random
         # fixed_params
         logg = 4.52
         vmic = 0.83
+        cntm_offset = 0.04
 
         synth_wls = 5000:0.01:5010
         obs_wls = 5003 : 0.03 : 5008
@@ -76,12 +77,12 @@ using Random
         # generate a spectrum and 
         atm = interpolate_marcs(Teff, logg, m_H)
         sol = synthesize(atm, linelist, format_A_X(m_H), [synth_wls]; vmic=vmic)
-        spectrum = LSF * (sol.flux ./ sol.cntm)
+        spectrum = LSF * (sol.flux ./ (sol.cntm .* (1 - cntm_offset)))
         err = 0.01 * ones(length(spectrum)) # don't actually apply error to keep tests deterministic
 
         # now fit it
         p0 = (Teff=5350.0, m_H=0.0)
-        fixed = (logg=logg, vmic=vmic)
+        fixed = (logg=logg, vmic=vmic, cntm_offset=cntm_offset)
         result = Korg.Fit.fit_spectrum(obs_wls, spectrum, err, linelist, p0, fixed; 
                                        synthesis_wls=synth_wls, LSF_matrix=LSF)
         


### PR DESCRIPTION
This add two fitting params `cntm_offset` and `cntm_slope` to `Korg.Fit.fit_spectrum`, which let you fit for adjustments to the continuum simultaneously with stellar parameters and abundances.

I also slightly refactored `fit_spectrum`, and fixed an edge-case indexing bug in `calculate_multilocal_masks_and_ranges`