### PR TITLE
Atmosphere interp overhaul

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,20 @@
-[SDSS_MARCS_atmospheres]
-git-tree-sha1 = "9a38707aa50c45a2950843e2773bb94512d2fad2"
+[MARCS_metal_poor_atmospheres]
+git-tree-sha1 = "7ccbdaf1a3709772953d75b0888e6d5ec359d90b"
 
-    [[SDSS_MARCS_atmospheres.download]]
-    sha256 = "cbe1845c18882104b2d8d84c1b3a54e85c358de648909822180755b1aaf553b4"
-    url = "https://korg-data.s3.amazonaws.com/SDSS_MARCS_atmospheres.tar.gz"
+    [[MARCS_metal_poor_atmospheres.download]]
+    sha256 = "d08dce5f1bb98e2f8b74db563ad47182722ba354d6cf8690aacac28bbd1f64f0"
+    url = "https://korg-data.s3.amazonaws.com/MARCS_metal_poor_atmospheres.tar.gz"
+
+[SDSS_MARCS_atmospheres_v2]
+git-tree-sha1 = "0e9cca0d99f7ad79aa966aa28c7be962071893e2"
+
+    [[SDSS_MARCS_atmospheres_v2.download]]
+    sha256 = "98a2d96805d255539e47ef3ae8671bcf776ca80cc4a50e09a47100c8477d80be"
+    url = "https://korg-data.s3.amazonaws.com/SDSS_MARCS_atmospheres_v2.tar.gz"
+
+[resampled_cool_dwarf_atmospheres]
+git-tree-sha1 = "cd6250126e449334f340641a545c2ab5c3d1bf7c"
+
+    [[resampled_cool_dwarf_atmospheres.download]]
+    sha256 = "385133c3b06f0a632ec05e3e58feaa7587b673c4a805eea07b9d0aa33386e940"
+    url = "https://korg-data.s3.amazonaws.com/resampled_cool_dwarf_atmospheres.tar.gz"

--- a/data/model_atmospheres/resample_onto_tau_5000.jl
+++ b/data/model_atmospheres/resample_onto_tau_5000.jl
@@ -1,0 +1,50 @@
+# resample the built-it grid of marcs model atmospheres for cool dwarfs onto a grid of consistent 
+# τ_5000 values. This was shown to improve accuracy tremendously in the Korg II paper.
+
+# this script was used to generate the file, but it isn't part of the Korg module.  The file is 
+# shipped via the artifact system alongside the big atmosphere archive.
+
+using Korg, HDF5, ProgressMeter, Interpolations
+
+function resample_grid(grid, new_log_taus; tau_index=4)
+    dims = size(grid)[3:end]
+    resampled_grid = Array{Float32}(undef, (length(new_log_taus), 5, dims...))
+    
+    @showprogress for I in CartesianIndices(dims)
+        for quant_ind in 1:5
+            if quant_ind != tau_index
+                itp = linear_interpolation(log10.(grid[:, tau_index, I]), grid[:, quant_ind, I], extrapolation_bc=Interpolations.Line())
+                resampled_grid[:, quant_ind, I] = itp.(new_log_taus)
+            end
+        end
+        resampled_grid[:, tau_index, I] .= 10 .^ new_log_taus
+        
+        # replace extrapolated values with nans.
+        #taumin, taumax = grid[begin, tau_index, I], grid[end, tau_index, I]
+        #resampled_grid[.! (log10(taumin) .< new_log_taus .< log10(taumax)), :, I] .= NaN
+    end
+    resampled_grid
+end
+
+nodes, grid = copy.(Korg._sdss_marcs_atmospheres);
+
+# cool dwarfs only
+Teff_mask = (nodes[1] .<= 4000) .& (nodes[1] .!= 3750)
+logg_mask = nodes[2] .>= 3.5
+nodes[1] = nodes[1][Teff_mask]
+nodes[2] = nodes[2][logg_mask]
+grid = grid[:, :, Teff_mask, logg_mask, :, :, :]
+
+new_log_taus = -6 : 0.1 : 2
+
+resampled_grid = resample_grid(grid, new_log_taus)
+
+# save to disk
+h5open("resampled_cool_dwarf_atmospheres.h5", "w") do f
+    write_attribute(f, "version", "2024-01-04")
+    f["grid"] = resampled_grid
+    f["grid_parameter_names"] = ["Teff", "logg", "metallicity", "alpha", "carbon"]
+    for i in 1:5
+        f["grid_values/$i"] = nodes[i]
+    end
+end

--- a/data/model_atmospheres/resample_onto_tau_5000.jl
+++ b/data/model_atmospheres/resample_onto_tau_5000.jl
@@ -7,7 +7,7 @@
 using Korg, HDF5, ProgressMeter, Interpolations
 
 function resample_grid(grid, new_log_taus; tau_index=4)
-    dims = size(grid)[3:end]
+    dims = size(grid)[3:end] # number of m_h, alpha_m, c_m points
     resampled_grid = Array{Float32}(undef, (length(new_log_taus), 5, dims...))
     
     @showprogress for I in CartesianIndices(dims)
@@ -20,6 +20,7 @@ function resample_grid(grid, new_log_taus; tau_index=4)
         resampled_grid[:, tau_index, I] .= 10 .^ new_log_taus
         
         # replace extrapolated values with nans.
+        # layers filled with NaNs will be dropped when constructing the atmosphere object
         #taumin, taumax = grid[begin, tau_index, I], grid[end, tau_index, I]
         #resampled_grid[.! (log10(taumin) .< new_log_taus .< log10(taumax)), :, I] .= NaN
     end

--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -1,7 +1,8 @@
 module Korg
     _data_dir = joinpath(@__DIR__, "../data") 
 
-    include("CubicSplines.jl")             # 1D cubic Splines
+    include("CubicSplines.jl")             # 1D cubic Splines with arbitrarily spaced knots
+    include("lazy_multilinear_interpolation.jl") # linear interpolation with minimal memory overhead
     include("constants.jl")                # physical constants
     include("atomic_data.jl")              # symbols and atomic weights
     include("isotopic_data.jl")            # abundances and nuclear spins

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -158,11 +158,13 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
 end
 
 const _sdss_marcs_atmospheres = let
-    path = joinpath(artifact"SDSS_MARCS_atmospheres", "SDSS_MARCS_atmospheres.h5")
-    exists = h5read(path, "exists")
-    grid = h5read(path, "grid")
-    nodes = [h5read(path, "grid_values/$i") for i in 1:5]
-    (nodes, exists, grid)
+    #path = joinpath(artifact"SDSS_MARCS_atmospheres", "SDSS_MARCS_atmospheres.h5")
+    path = "/Users/wheeler.883/Dropbox/Korg_data/MARCS_data/SDSS_MARCS_atmospheres.h5"
+    h5open(path, "r") do f
+        grid = HDF5.readmmap(f["grid"])
+        nodes = [read(f["grid_values/$i"]) for i in 1:5]
+        nodes, grid
+    end
 end
 
 """
@@ -195,8 +197,7 @@ The model atmosphere grid is a repacked version of the
 !!! warning
     Atmosphere interpolation contributes non-negligeble error to synthesized spectra below 
     Teff ≈ 4250 K. We do not endorse using it for science in that regime. See 
-    https://github.com/ajwheeler/Korg.jl/issues/164 for a discussion of the issue.
-"""
+    https://github.com/ajwheeler/Korg.jl/issues/164 for a discussion of the issue.  """
 function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real}; 
                            solar_abundances=grevesse_2007_solar_abundances, 
                            clamp_abundances=false, kwargs...)
@@ -215,7 +216,7 @@ function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real};
 end
 function interpolate_marcs(Teff, logg, M_H=0, alpha_M=0, C_M=0; spherical=logg < 3.5, 
                            perturb_at_grid_values=false, archive=_sdss_marcs_atmospheres)
-    nodes, _, grid = archive 
+    nodes, grid = archive 
 
     params = [Teff, logg, M_H, alpha_M, C_M]
     param_names = ["Teff", "log(g)", "[M/H]", "[alpha/M]", "[C/metals]"]

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -223,18 +223,22 @@ function interpolate_marcs(Teff, logg, M_H=0, alpha_M=0, C_M=0; spherical=logg <
     atm_quants = lazy_multilinear_interpolation(params, nodes, grid, param_names=param_names, 
                                                perturb_at_grid_values=perturb_at_grid_values)
 
+    
+    # less extended atmospheres will have NaNs past the extremem tau values.
+    nanmask = .! isnan.(atm_quants[:, 4])
+
     if spherical
         R = sqrt(G_cgs * solar_mass_cgs / 10^(logg)) 
-        ShellAtmosphere(ShellAtmosphereLayer.(atm_quants[:, 4], 
-                                              sinh.(atm_quants[:, 5]), 
-                                              atm_quants[:, 1],
-                                              exp.(atm_quants[:, 2]), 
-                                              exp.(atm_quants[:, 3])), R)
+        ShellAtmosphere(ShellAtmosphereLayer.(atm_quants[nanmask, 4], 
+                                              sinh.(atm_quants[nanmask, 5]), 
+                                              atm_quants[nanmask, 1],
+                                              exp.(atm_quants[nanmask, 2]), 
+                                              exp.(atm_quants[nanmask, 3])), R)
     else
-        PlanarAtmosphere(PlanarAtmosphereLayer.(atm_quants[:, 4], 
-                                               sinh.(atm_quants[:, 5]), 
-                                               atm_quants[:, 1],
-                                               exp.(atm_quants[:, 2]), 
-                                               exp.(atm_quants[:, 3])))
+        PlanarAtmosphere(PlanarAtmosphereLayer.(atm_quants[nanmask, 4], 
+                                               sinh.(atm_quants[nanmask, 5]), 
+                                               atm_quants[nanmask, 1],
+                                               exp.(atm_quants[nanmask, 2]), 
+                                               exp.(atm_quants[nanmask, 3])))
     end
 end

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -208,17 +208,28 @@ const _cool_dwarfs_atm_itp = let
 end
 
 """
-    interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; kwargs...)
     interpolate_marcs(Teff, logg, A_X; kwargs...)
+    interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; kwargs...)
 
-Returns a model atmosphere obtained by interpolating the MARCS SDSS atmosphere grid, which provides 
-atmospheres for varying values of ``T_\\mathrm{eff}``, ``\\log g``, [metals/H], [alpha/metals], 
-and [C/metals].  If the `A_X` (a vector of abundances in the format returned by [`format_A_X`](@ref)
-and accepted by [`synthesize`](@ref)) is provided instead of `M_H`, `alpha_M`, and `C_M`, the 
-solar-relative ratios will be reconstructed assuming Grevesse+ 2007 solar abundances.
+Returns a model atmosphere computed by interpolating models from [MARCS](https://marcs.astro.uu.se/)
+((Gustafsson+ 2008)[https://ui.adsabs.harvard.edu/abs/2008A&A...486..951G/abstract]).
+Along with `Teff` and `logg`, the atmosphere is specified by `M_H`, `alpha_M`, and `C_M`, which can 
+be automatically determined from an `A_X` abundance vector (the recommended method, 
+see [`format_A_X`](@ref)). Note that the MARCS atmosphere models were constructed with the 
+Grevesse+ 2007 solar abundances (`Korg.grevesse_2007_solar_abundances`). This is handled 
+automatically when `A_X` is provided.
 
-The model atmosphere grid is a repacked version of the 
-[MARCS SDSS grid](https://dr17.sdss.org/sas/dr17/apogee/spectro/speclib/atmos/marcs/MARCS_v3_2016/Readme_MARCS_v3_2016.txt).
+`interpolate_marcs` uses three different interpolation schemes for different stellar parameter
+regimes. In the standard case the model atmosphere grid is [the one generated for
+SDSS](https://dr17.sdss.org/sas/dr17/apogee/spectro/speclib/atmos/marcs/MARCS_v3_2016/Readme_MARCS_v3_2016.txt),
+transformed and linearly interpolated. For cool dwarfs (`Teff` ≤ 4000 K, `logg` ≥ 3.5), the grid is
+resampled onto unchanging `tau_5000` values and interpolated with a cubic spline. For
+low-metallicity models (-5 ≤ `m_H` < -2.5), a grid of standard composition (i.e. fixed alpha and C)
+atmospheres is used.  (The microturbulence is 1km/s for dwarfs and 2km/s for giants and the mass for
+spherical models is 1 solar mass.) The interpolation method is the same as in the standard case. See
+[Wheeler+ 2024](https://ui.adsabs.harvard.edu/abs/2023arXiv231019823W/abstract) for more details and
+a discussion of errors introduced by model atmosphere interpolation. (Note that the cubic scheme for
+cool dwarfs is referred to as not-yet-implemented in the paper but is now available.)
 
 # keyword arguments
 - `spherical`: whether or not to return a ShellAtmosphere (as opposed to a PlanarAtmosphere).  By 
@@ -226,21 +237,16 @@ The model atmosphere grid is a repacked version of the
 - `solar_abundances`: (default: `grevesse_2007_solar_abundances`) The solar abundances to use when 
   `A_X` is provided instead of `M_H`, `alpha_M`, and `C_M`. The default is chosen to match that of 
   the atmosphere grid, and is probably no good reason to change it.
-- `clamp_abundances`: (default: `false`) allowed when specifying `A_X` direction. Whether or not to 
-   clamp the abundance paramerters to be within the range of the MARCS grid to avoid throwing an out 
-   of bounds error. Use with caution.
-- `perturb_at_grid_values`: when true this will add or a subtract a very small number to each 
-   parameter which is exactly at a grid value. This prevents null derivatives, which can cause 
-   problems for minimizers.  
+- `clamp_abundances`: (default: `false`) allowed only when specifying `A_X`. Whether or not to 
+   clamp the abundance parameters to be within range to avoid throwing an out of bounds error.
+- `perturb_at_grid_values` (default: `true`): whether or not to add or a subtract a very small 
+   number to each parameter which is exactly at a grid value. This prevents null derivatives, which 
+   can cause problems for minimizers. 
 - `archives`: A tuple containing the atmosphere grids to use.  For testing purposes.
-
-!!! warning
-    Atmosphere interpolation contributes non-negligeble error to synthesized spectra below 
-    Teff ≈ 4250 K. We do not endorse using it for science in that regime. See 
-    https://github.com/ajwheeler/Korg.jl/issues/164 for a discussion of the issue.  """
+"""
 function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real}; 
                            solar_abundances=grevesse_2007_solar_abundances, 
-                           clamp_abundances=true, 
+                           clamp_abundances=false, 
                            archives=(_sdss_marcs_atmospheres, _cool_dwarfs_atm_itp, _low_Z_marcs_atmospheres),
                            kwargs...)
     m_H = get_metals_H(A_X; solar_abundances=solar_abundances)
@@ -266,7 +272,7 @@ function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real};
     interpolate_marcs(Teff, logg, m_H, alpha_m, C_m; archives=archives, kwargs...)
 end
 function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg < 3.5, 
-                           perturb_at_grid_values=false, resampled_cubic_for_cool_dwarfs=true,
+                           perturb_at_grid_values=true, resampled_cubic_for_cool_dwarfs=true,
                            archives=(_sdss_marcs_atmospheres, _cool_dwarfs_atm_itp, _low_Z_marcs_atmospheres))
     if Teff <= 4000 && logg >= 3.5 && m_H >= -2.5 && resampled_cubic_for_cool_dwarfs
         itp, nlayers = archives[2]

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -157,8 +157,6 @@ function read_model_atmosphere(fname::AbstractString) :: ModelAtmosphere
      end
 end
 
-# this isn't a const because the model atmosphere doesn't get loaded into memory until 
-# interpolate_marcs is called for the first time
 const _sdss_marcs_atmospheres = let
     path = joinpath(artifact"SDSS_MARCS_atmospheres", "SDSS_MARCS_atmospheres.h5")
     exists = h5read(path, "exists")
@@ -166,7 +164,6 @@ const _sdss_marcs_atmospheres = let
     nodes = [h5read(path, "grid_values/$i") for i in 1:5]
     (nodes, exists, grid)
 end
-
 
 """
     interpolate_marcs(Teff, logg, Fe_M=0, alpha_M=0, C_M=0; kwargs...)
@@ -218,73 +215,13 @@ function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real};
 end
 function interpolate_marcs(Teff, logg, M_H=0, alpha_M=0, C_M=0; spherical=logg < 3.5, 
                            perturb_at_grid_values=false, archive=_sdss_marcs_atmospheres)
-    nodes, exists, grid = archive 
+    nodes, _, grid = archive 
 
     params = [Teff, logg, M_H, alpha_M, C_M]
     param_names = ["Teff", "log(g)", "[M/H]", "[alpha/M]", "[C/metals]"]
+    atm_quants = lazy_multilinear_interpolation(params, nodes, grid, param_names=param_names, 
+                                               perturb_at_grid_values=perturb_at_grid_values)
 
-    if perturb_at_grid_values
-        # add small offset to each parameter which is exactly at grid value
-        # this prevents the derivatives from being exactly zero
-        on_grid_mask = in.(params, nodes)
-        params[on_grid_mask] .= nextfloat.(params[on_grid_mask])
-
-        # take care of the case where the parameter is at the last grid value
-        too_high_mask = params .> last.(nodes)
-        params[too_high_mask] .= prevfloat.(params[too_high_mask])
-        params[too_high_mask] .= prevfloat.(params[too_high_mask])
-    end
-    
-    upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)
-        if !(p_nodes[1] <= p <= p_nodes[end])
-            throw(ArgumentError("Can't interpolate atmosphere grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
-        end
-        findfirst(p .<= p_nodes)
-    end
-    isexact = params .== getindex.(nodes, upper_vertex) #which params are on grid points?
-    
-    # allocate 2^n cube for each quantity
-    dims = Tuple(2 for _ in upper_vertex) #dimensions of 2^n hypercube
-    structure_type = typeof(promote(Teff, logg, M_H, alpha_M, C_M)[1])
-    structure = Array{structure_type}(undef, (56, 5, dims...))
-     
-    #put bounding atmospheres in 2^n cube
-    for I in CartesianIndices(dims)
-        local_inds = collect(Tuple(I))
-        atm_inds = copy(local_inds)
-        atm_inds[isexact] .= 2 #use the "upper bound" as "lower bound" if the param is on a grid point
-        atm_inds .+= upper_vertex .- 2
-
-        if !exists[atm_inds...] #return nothing if any required nodes don't exist
-            @info str(getindex.(nodes, atm_inds), " doesn't exist") 
-            return 
-        end
-        
-        structure[:, :, local_inds...] .= grid[:, :, atm_inds...]
-    end
-
-    for i in 1:length(params) #loop over Teff, logg, etc.
-        isexact[i] && continue #no need to do anything for exact params
-        
-        # the bounding values of the parameter you are currently interpolating over 
-        p1 = nodes[i][upper_vertex[i]-1]
-        p2 = nodes[i][upper_vertex[i]]
-        
-        # inds1 and inds2 are the expressions for the slices through the as-of-yet 
-        # uninterpolated quantities (temp, logPg, etc) for each node value of the
-        # quantity being interpolated
-        # inds1 = (1, 1, 1, ..., 1, 1, :, :, ...)
-        # inds2 = (1, 1, 1, ..., 1, 2, :, :, ...)
-        inds1 = vcat([1 for _ in 1:i-1], 1, [Colon() for _ in i+1:length(params)])
-        inds2 = vcat([1 for _ in 1:i-1], 2, [Colon() for _ in i+1:length(params)])
-        
-        x = (params[i] - p1) / (p2 - p1) #maybe try using masseron alpha later
-        for structure_ind in 1:5 #TODO fix
-            structure[:, structure_ind, inds1...] = (1-x)*structure[:, structure_ind, inds1...] + x*structure[:, structure_ind, inds2...]
-        end
-    end
-   
-    atm_quants = (structure[:, :, ones(Int, length(params))...])
     if spherical
         R = sqrt(G_cgs * solar_mass_cgs / 10^(logg)) 
         ShellAtmosphere(ShellAtmosphereLayer.(atm_quants[:, 4], 

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -170,12 +170,12 @@ function _prepare_linear_atmosphere_archive(path)
     end
 end
 _sdss_marcs_atmospheres = let 
-    #path = joinpath(artifact"SDSS_MARCS_atmospheres", "SDSS_MARCS_atmospheres.h5")
-    path = "/Users/wheeler.883/Dropbox/Korg_data/MARCS_data/SDSS_MARCS_atmospheres.h5"
-    _prepare_linear_atmosphere_archive("/Users/wheeler.883/Dropbox/Korg_data/MARCS_data/SDSS_MARCS_atmospheres.h5")
+    # note to self: don't put files in a directory before you tarball it next time.  It's redundant!
+    path = joinpath(artifact"SDSS_MARCS_atmospheres_v2", "SDSS_MARCS_atmospheres", "SDSS_MARCS_atmospheres.h5")
+    _prepare_linear_atmosphere_archive(path)
 end
 _low_Z_marcs_atmospheres = let 
-    path = "/Users/wheeler.883/Dropbox/Korg_data/MARCS_data/MARCS_metal_poor_atmospheres.h5"
+    path = joinpath(artifact"MARCS_metal_poor_atmospheres", "MARCS_metal_poor_atmospheres", "MARCS_metal_poor_atmospheres.h5")
     _prepare_linear_atmosphere_archive(path)
 end
 
@@ -200,7 +200,7 @@ function _prepare_cool_dwarf_atm_archive(grid, nodes)
     itp, nlayers
 end
 const _cool_dwarfs_atm_itp = let 
-    path = "/Users/wheeler.883/Dropbox/Korg/data/model_atmospheres/resampled_cool_dwarf_atmospheres.h5"
+    path = joinpath(artifact"resampled_cool_dwarf_atmospheres", "resampled_cool_dwarf_atmospheres", "resampled_cool_dwarf_atmospheres.h5")
     grid, nodes = h5open(path, "r") do f
         read(f["grid"]), [read(f["grid_values/$i"]) for i in 1:5]
     end

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -213,7 +213,7 @@ end
 
 Returns a model atmosphere computed by interpolating models from [MARCS](https://marcs.astro.uu.se/)
 ((Gustafsson+ 2008)[https://ui.adsabs.harvard.edu/abs/2008A&A...486..951G/abstract]).
-Along with `Teff` and `logg`, the atmosphere is specified by `M_H`, `alpha_M`, and `C_M`, which can 
+Along with `Teff` and `logg`, the atmosphere is specified by `m_H`, `alpha_m`, and `C_m`, which can 
 be automatically determined from an `A_X` abundance vector (the recommended method, 
 see [`format_A_X`](@ref)). Note that the MARCS atmosphere models were constructed with the 
 Grevesse+ 2007 solar abundances (`Korg.grevesse_2007_solar_abundances`). This is handled 
@@ -236,12 +236,13 @@ cool dwarfs is referred to as not-yet-implemented in the paper but is now availa
   default true when `logg` < 3.5.
 - `solar_abundances`: (default: `grevesse_2007_solar_abundances`) The solar abundances to use when 
   `A_X` is provided instead of `M_H`, `alpha_M`, and `C_M`. The default is chosen to match that of 
-  the atmosphere grid, and is probably no good reason to change it.
+  the atmosphere grid, and if you change it you are likely trying to do something else.
 - `clamp_abundances`: (default: `false`) allowed only when specifying `A_X`. Whether or not to 
    clamp the abundance parameters to be within range to avoid throwing an out of bounds error.
 - `perturb_at_grid_values` (default: `true`): whether or not to add or a subtract a very small 
    number to each parameter which is exactly at a grid value. This prevents null derivatives, which 
    can cause problems for minimizers. 
+- `resampled_cubic_for_cool_dwarfs` (default: `true`): whether or not to used specialized method for cool dwarfs.
 - `archives`: A tuple containing the atmosphere grids to use.  For testing purposes.
 """
 function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real}; 

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -253,7 +253,7 @@ function interpolate_marcs(Teff, logg, A_X::AbstractVector{<:Real};
         nodes = archives[1][1] # nodes for the standard grid
         # -5 is the lowest value for [M/H] in the standard grid
         M_H = clamp(M_H, -5, nodes[3][end])
-        alpha_M = clamp(C_M, nodes[4][1], nodes[4][end])
+        alpha_M = clamp(alpha_M, nodes[4][1], nodes[4][end])
         C_M = clamp(C_M, nodes[5][1], nodes[5][end])
     end
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -592,12 +592,13 @@ function ews_to_stellar_parameters(linelist, measured_EWs, measured_EW_err=ones(
     if parameter_ranges[3][1] <= 0.0
         throw(ArgumentError("The lower bound of vmic must be greater than zero. (vmic must be nonzero in order to avoid null derivatives. Very small values are fine.)"))
     end
-    # the widest parameter ranges allowed by the MARCS grid
+
+    # the widest parameter ranges allowed for model atmosphere interp
     atm_lb = first.(Korg._sdss_marcs_atmospheres[1][1:3])
+    atm_lb[3] = Korg._low_Z_marcs_atmospheres[1][3][1]
     atm_ub = last.(Korg._sdss_marcs_atmospheres[1][1:3])
-    # index 3 in vmic, which isn't in the MARCS grid
     if any(first.(parameter_ranges[[1, 2, 4]]) .< atm_lb) || any(last.(parameter_ranges[[1, 2, 4]]) .> atm_ub)
-        throw(ArgumentError("The parameter ranges must be within the range of the MARCS grid ()"))
+        throw(ArgumentError("The parameter ranges must be within the range of the MARCS grid"))
     end
 
     params0 = [Teff0, logg0, vmic0, m_H0]

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -209,9 +209,9 @@ values are used.
 - `wl_buffer` is the number of Å to add to each side of the synthesis range for each window.
 - `precision` specifies the tolerance for the solver to accept a solution. The solver operates on 
    transformed parameters, so `precision` doesn't translate straightforwardly to Teff, logg, etc, but 
-   the default is, `1e-4`, provides a theoretical worst-case tolerance of about 0.15 K in `Teff`, 
+   the default value, `1e-4`, provides a theoretical worst-case tolerance of about 0.15 K in `Teff`, 
    0.0002 in `logg`, 0.0001 in `m_H`, and 0.0004 in detailed abundances. In practice the precision 
-   acheived by the optimizer is about 10x bigger than this at worst.
+   achieved by the optimizer is about 10x bigger than this.
 Any additional keyword arguments will be passed to [`Korg.synthesize`](@ref) when synthesizing the
 spectra for the fit.
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -30,7 +30,7 @@ const tan_scale_params = Dict(
     # Korg.interpolate_marcs.
     "Teff" => (2800, 8000),
     "logg" => (-0.5, 5.5),
-    "m_H" => (-2.5, 1),
+    "m_H" => (-5, 1),
     # this allows all the atmospheres supported by the grid, but also many that are not.
     # alpha will be clamped to the nearest supported value.
     "alpha_H" => (-3.5, 2), 
@@ -563,7 +563,7 @@ function ews_to_stellar_parameters(linelist, measured_EWs, measured_EW_err=ones(
                                    max_step_sizes=[1000.0, 1.0, 0.3, 0.5],
                                    parameter_ranges=[extrema.(Korg._sdss_marcs_atmospheres[1][1:2]) 
                                                     ; (1e-3, 10.0) 
-                                                    ; extrema(Korg._sdss_marcs_atmospheres[1][3])],
+                                                    ; (Korg._low_Z_marcs_atmospheres[1][3][1], Korg._sdss_marcs_atmospheres[1][3][end])],
                                    fix_params=[false, false, false, false],
                                    callback=Returns(nothing), max_iterations=30, passed_kwargs...)
     if :vmic in keys(passed_kwargs)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -209,8 +209,9 @@ values are used.
 - `wl_buffer` is the number of Å to add to each side of the synthesis range for each window.
 - `precision` specifies the tolerance for the solver to accept a solution. The solver operates on 
    transformed parameters, so `precision` doesn't translate straightforwardly to Teff, logg, etc, but 
-   the default is, `1e-3`, provides a worst-case tolerance of about 1.5K in `Teff`, 0.002 in `logg`, 
-   0.001 in `m_H`, and 0.004 in detailed abundances.
+   the default is, `1e-4`, provides a theoretical worst-case tolerance of about 0.15 K in `Teff`, 
+   0.0002 in `logg`, 0.0001 in `m_H`, and 0.0004 in detailed abundances. In practice the precision 
+   acheived by the optimizer is about 10x bigger than this at worst.
 Any additional keyword arguments will be passed to [`Korg.synthesize`](@ref) when synthesizing the
 spectra for the fit.
 
@@ -231,7 +232,7 @@ A NamedTuple with the following fields:
   Nelder-Mead), this is not provided.
 
 !!! tip
-    The function takes a long time to compile the first time it is called. Compilation performance 
+    This function takes a long time to compile the first time it is called. Compilation performance 
     is significantly better on Julia 1.10 than previous versions, so if you are using an older
     version of Julia, you may want to upgrade.
 """
@@ -244,7 +245,7 @@ function fit_spectrum(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fix
                       else
                           Korg.compute_LSF_matrix(synthesis_wls, obs_wls, R)
                       end,
-                      wl_buffer=1.0, precision=1e-3, synthesis_kwargs...)
+                      wl_buffer=1.0, precision=1e-4, synthesis_kwargs...)
     if length(obs_wls) != length(obs_flux) || length(obs_wls) != length(obs_err)
         throw(ArgumentError("obs_wls, obs_flux, and obs_err must all have the same length."))
     end
@@ -293,7 +294,7 @@ function fit_spectrum(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fix
     end 
     
     # call optimization library
-    res = optimize(chi2, p0, BFGS(linesearch=LineSearches.BackTracking()),
+    res = optimize(chi2, p0, BFGS(linesearch=LineSearches.BackTracking(maxstep=1.0)),
              Optim.Options(x_tol=precision, time_limit=10_000, store_trace=true, 
                            extended_trace=true); autodiff=:forward)
 

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -7,8 +7,7 @@ minimize the number of reads from the grid, and access things in an efficient or
 It is much faster than Interpolations.linear_interpolation when applied to memory-mapped grids.
 At present it is used only for model atmosphere and departure coefficient interpolation.
 
-See also: [`interpolate_marcs`](@ref), [`interpolate_departure_coefs_and_atm`](@ref), 
-[`Korg.CubicSplines`](@ref)
+See also: [`interpolate_marcs`](@ref), [`Korg.CubicSplines.CubicSpline`](@ref)
 """
 function lazy_multilinear_interpolation(params, nodes, grid; 
                                         param_names=["param $i" for i in 1:length(params)],

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -27,7 +27,7 @@ function lazy_multilinear_interpolation(params, nodes, grid;
     
     upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)
         if !(p_nodes[1] <= p <= p_nodes[end])
-            throw(ArgumentError("Can't interpolate atmosphere grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
+            throw(ArgumentError("Can't interpolate grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
         end
         findfirst(p .<= p_nodes)
     end

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -45,7 +45,7 @@ function lazy_multilinear_interpolation(params, nodes, grid;
         atm_inds[isexact] .= 2 #use the "upper bound" as "lower bound" if the param is on a grid point
         atm_inds .+= upper_vertex .- 2
 
-        structure[:, :, local_inds...] .= grid[:, :, atm_inds...]
+        @views structure[:, :, local_inds...] .= grid[:, :, atm_inds...]
     end
 
     for i in eachindex(params) #loop over interpolation parameters
@@ -64,7 +64,7 @@ function lazy_multilinear_interpolation(params, nodes, grid;
         inds2 = vcat([1 for _ in 1:i-1], 2, [Colon() for _ in i+1:length(params)])
         
         x = (params[i] - p1) / (p2 - p1) #maybe try using masseron alpha later
-        structure[:, :, inds1...] = (1-x)*structure[:, :, inds1...] + x*structure[:, :, inds2...]
+        @views structure[:, :, inds1...] = (1-x)*structure[:, :, inds1...] + x*structure[:, :, inds2...]
     end
     structure[:, :, ones(Int, length(params))...]
 end

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -2,7 +2,7 @@
     lazy_multilinear_interpolation(params, nodes, grid; kwargs...)
 
 This function is does multidimensional linear interpolation on a grid where the first two dimensions
-represent the values being interplated.  In other words, it interpolates matrices. It is written to 
+represent the values being interpolated.  In other words, it interpolates matrices. It is written to 
 minimize the number of reads from the grid, and access things in an efficient order.
 It is much faster than Interpolations.linear_interpolation when applied to memory-mapped grids.
 At present it is used only for model atmosphere and departure coefficient interpolation.

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -1,0 +1,70 @@
+"""
+    lazy_multilinear_interpolation(params, nodes, grid; kwargs...)
+
+This function is does multidimensional linear interpolation on a grid where the first two dimensions
+represent the values being interplated.  In other words, it interpolates matrices. It is written to 
+minimize the number of reads from the grid, and access things in an efficient order.
+It is much faster than Interpolations.linear_interpolation when applied to memory-mapped grids.
+At present it is used only for model atmosphere and departure coefficient interpolation.
+
+See also: [`interpolate_marcs`](@ref), [`interpolate_departure_coefs_and_atm`](@ref), 
+[`Korg.CubicSplines`](@ref)
+"""
+function lazy_multilinear_interpolation(params, nodes, grid; 
+                                        param_names=["param $i" for i in 1:length(params)],
+                                        perturb_at_grid_values=false)
+    if perturb_at_grid_values
+        # add small offset to each parameter which is exactly at grid value
+        # this prevents the derivatives from being exactly zero
+        on_grid_mask = in.(params, nodes)
+        params[on_grid_mask] .= nextfloat.(params[on_grid_mask])
+
+        # take care of the case where the parameter is at the last grid value
+        too_high_mask = params .> last.(nodes)
+        params[too_high_mask] .= prevfloat.(params[too_high_mask])
+        params[too_high_mask] .= prevfloat.(params[too_high_mask])
+    end
+    
+    upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)
+        if !(p_nodes[1] <= p <= p_nodes[end])
+            throw(ArgumentError("Can't interpolate atmosphere grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
+        end
+        findfirst(p .<= p_nodes)
+    end
+    isexact = params .== getindex.(nodes, upper_vertex) #which params are on grid points?
+    
+    # allocate 2^n cube for each quantity
+    dims = Tuple(2 for _ in upper_vertex) #dimensions of 2^n hypercube
+    structure_type = typeof(promote(params...)[1])
+    structure = Array{structure_type}(undef, (size(grid)[1:2]..., dims...))
+     
+    #put bounding atmospheres in 2^n cube
+    for I in CartesianIndices(dims)
+        local_inds = collect(Tuple(I))
+        atm_inds = copy(local_inds)
+        atm_inds[isexact] .= 2 #use the "upper bound" as "lower bound" if the param is on a grid point
+        atm_inds .+= upper_vertex .- 2
+
+        structure[:, :, local_inds...] .= grid[:, :, atm_inds...]
+    end
+
+    for i in eachindex(params) #loop over interpolation parameters
+        isexact[i] && continue #no need to do anything for exact params
+        
+        # the bounding values of the parameter you are currently interpolating over 
+        p1 = nodes[i][upper_vertex[i]-1]
+        p2 = nodes[i][upper_vertex[i]]
+        
+        # inds1 and inds2 are the expressions for the slices through the as-of-yet 
+        # uninterpolated quantities (temp, logPg, etc for atm itp) for each node value 
+        # of the quantity being interpolated
+        # inds1 = (1, 1, 1, ..., 1, 1, :, :, ...)
+        # inds2 = (1, 1, 1, ..., 1, 2, :, :, ...)
+        inds1 = vcat([1 for _ in 1:i-1], 1, [Colon() for _ in i+1:length(params)])
+        inds2 = vcat([1 for _ in 1:i-1], 2, [Colon() for _ in i+1:length(params)])
+        
+        x = (params[i] - p1) / (p2 - p1) #maybe try using masseron alpha later
+        structure[:, :, inds1...] = (1-x)*structure[:, :, inds1...] + x*structure[:, :, inds2...]
+    end
+    structure[:, :, ones(Int, length(params))...]
+end

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -27,7 +27,9 @@ function lazy_multilinear_interpolation(params, nodes, grid;
     
     upper_vertex = map(zip(params, param_names, nodes)) do (p, p_name, p_nodes)
         if !(p_nodes[1] <= p <= p_nodes[end])
-            throw(ArgumentError("Can't interpolate grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])"))
+            msg = "Can't interpolate grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])." * 
+                  " If you got the message calling `interpolate_marcs`, consider setting `clamp_abundances=true`."
+            throw(ArgumentError(msg))
         end
         findfirst(p .<= p_nodes)
     end

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -283,7 +283,7 @@ You can specify abundance with these positional arguments.  All are optional, bu
 - `default_metals_H` (default: 0), i.e. [metals/H] is the ``\\log_{10}`` solar-relative abundance of elements heavier 
    than He. It is overridden by `default_alpha` and `abundances` on a per-element basis.  
 - `default_alpha_H` (default: same as `default_metals_H`), i.e. [alpha/H] is the ``\\log_{10}`` 
-   solar-relative abundance of the alpha elements (defined to be C, O, Ne, Mg, Si, S, Ar, Ca, and 
+   solar-relative abundance of the alpha elements (defined to be O, Ne, Mg, Si, S, Ar, Ca, and 
    Ti). It is overridden by `abundances` on a per-element basis.
 - `abundances` is a `Dict` mapping atomic numbers or symbols to [``X``/H] abundances.  (Set 
   `solar_relative=false` to use ``A(X)`` abundances instead.) These override `default_metals_H`.
@@ -334,7 +334,7 @@ function format_A_X(default_metals_H::R1=0.0, default_alpha_H::R2=default_metals
     end
 
     #populate A(X) vector
-    alpha_els = [6, 8, 10, 12, 14, 16, 18, 20, 22]
+    alpha_els = [8, 10, 12, 14, 16, 18, 20, 22]
     map(1:MAX_ATOMIC_NUMBER) do Z
         if Z == 1 #handle hydrogen
             12.0
@@ -386,8 +386,8 @@ end
     get_alpha_H(A_X; solar_abundances=default_solar_abundances)
 
 Calculate [α/H] given a vector, `A_X` of absolute abundances, ``A(X) = \\log_{10}(n_α/n_\\mathrm{H})``.
-Here, the alpha elements are defined to be C, O, Ne, Mg, Si, S, Ar, Ca, Ti.  See also 
-[`get_alpha_H`](@ref).
+Here, the alpha elements are defined to be O, Ne, Mg, Si, S, Ar, Ca, Ti.  See also 
+[`get_metals_H`](@ref).
 
 # Keyword Arguments
 - `solar_abundances` (default: `Korg.asplund_2020_solar_abundances`) is the set of solar abundances to 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -405,9 +405,9 @@ numbers.  This is used to calculate, for example, [α/H] and [metals/H].
 """
 function _get_multi_X_H(A_X, Zs, solar_abundances)
     # there is no logsumexp in the julia stdlib, but it would make this more stable.
-    # these are missing "+ 12", but it cancels out
-    A_mX = log10(sum(10^A_X[Z] - 12 for Z in Zs))
-    A_mX_solar = log10(sum(10^solar_abundances[Z] - 12 for Z in Zs))
+    # the lack of "12"s here is not a mistake.  They all cancel.
+    A_mX = log10(sum(10^A_X[Z] for Z in Zs))
+    A_mX_solar = log10(sum(10^solar_abundances[Z] for Z in Zs))
     A_mX - A_mX_solar
 end
 

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -78,9 +78,9 @@
 
             atm1 = interpolate_marcs(5000.0, 3.0, 0, -1.0)
 
-            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances, clamp_abundances=true)
+            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances)
             @test_throws ArgumentError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
-            atm2 = interpolate_marcs(5000.0, 3.0, A_X)
+            atm2 = interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=true)
 
             @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
         end

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -78,7 +78,7 @@
 
             atm1 = interpolate_marcs(5000.0, 3.0, 0, -1.0)
 
-            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances; clamp_abundances=true)
+            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances, clamp_abundances=true)
             @test_throws ArgumentError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
             atm2 = interpolate_marcs(5000.0, 3.0, A_X)
 

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -2,7 +2,9 @@
     function assert_atmospheres_close(atm1, atm2; rtol=1e-3)
         val = true
         for f in [Korg.get_tau_5000s, Korg.get_zs, Korg.get_temps, Korg.get_number_densities, Korg.get_electron_number_densities]
-            val &= assert_allclose(f(atm1), f(atm2); rtol=rtol, print_rachet_info=false)
+            # convert rtol to atol to avoid issues with z values, which cross 0.
+            atol = rtol * maximum(abs.(f(atm1)))
+            val &= assert_allclose(f(atm1), f(atm2); atol=atol, rtol=0, print_rachet_info=false)
         end
         val
     end
@@ -73,14 +75,13 @@
         @testset "clamping abundances" begin
             m_H_nodes = Korg._sdss_marcs_atmospheres[1][3]
 
-            atm1 = interpolate_marcs(5000.0, 3.0, m_H_nodes[1])
-            A_X_2 = format_A_X(m_H_nodes[1] - 1; solar_abundances=Korg.grevesse_2007_solar_abundances)
-            atm2 = interpolate_marcs(5000.0, 3.0, A_X_2; clamp_abundances=true)
-            @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
 
-            atm1 = interpolate_marcs(5000.0, 3.0, m_H_nodes[end])
-            A_X_2 = format_A_X(m_H_nodes[end] + 1; solar_abundances=Korg.grevesse_2007_solar_abundances)
-            atm2 = interpolate_marcs(5000.0, 3.0, A_X_2; clamp_abundances=true)
+            atm1 = interpolate_marcs(5000.0, 3.0, 0, -1.0)
+
+            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances)
+            @test_throws ArgumentError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
+            atm2 = interpolate_marcs(5000.0, 3.0, A_X)
+
             @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
         end
 
@@ -93,7 +94,7 @@
             # values are not precisely identical.  I think this is due to slightly different solar mixtures.
             @test assert_atmospheres_close(atm1, atm2; rtol=2e-3)
 
-            # two interpolation schemes should give the same result at grid points
+            # cool dwarf and standard interpolation schemes should give the same result at grid points
             atm1 = Korg.interpolate_marcs(3000, 4.0; resampled_cubic_for_cool_dwarfs=true)
             atm2 = Korg.interpolate_marcs(3000, 4.0; resampled_cubic_for_cool_dwarfs=false)
 
@@ -103,8 +104,15 @@
             for f in [Korg.get_temps, Korg.get_number_densities, Korg.get_electron_number_densities]
                 itp = linear_interpolation(logτs1, f(atm1))
                 fs = itp(logτs2[5:end-5])
-                @test assert_allclose(f(atm2)[5:end-5], fs; rtol=1e-2)
+                @test assert_allclose(f(atm2)[5:end-5], fs; rtol=1e-2, print_rachet_info=false)
             end
+        end
+
+        @testset "low-metallicity" begin
+            δ = 1e-3
+            atm1 = interpolate_marcs(5000.0, 4.5, -2.5+δ, 0.4)
+            atm2 = interpolate_marcs(5000.0, 4.5, -2.5-δ, 0.4)
+            @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
         end
     end
 end

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -113,6 +113,14 @@
             atm1 = interpolate_marcs(5000.0, 4.5, -2.5+δ, 0.4)
             atm2 = interpolate_marcs(5000.0, 4.5, -2.5-δ, 0.4)
             @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
+
+            # set up A_X with abundances that don't match the MARCS standard comp
+            # it should still work
+            A_X = format_A_X(-2.5-δ, 0.3, Dict("C"=>0.1); solar_abundances=Korg.grevesse_2007_solar_abundances)
+            atm3 = interpolate_marcs(5000.0, 4.5, A_X)
+            @test assert_atmospheres_close(atm2, atm3; rtol=1e-10)
+
+            @test_throws ArgumentError interpolate_marcs(5000, 4.5, -3, 0)
         end
     end
 end

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -78,7 +78,7 @@
 
             atm1 = interpolate_marcs(5000.0, 3.0, 0, -1.0)
 
-            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances)
+            A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances; clamp_abundances=true)
             @test_throws ArgumentError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
             atm2 = interpolate_marcs(5000.0, 3.0, A_X)
 

--- a/test/synthesize.jl
+++ b/test/synthesize.jl
@@ -68,19 +68,22 @@
         @test_throws ArgumentError format_A_X(0.0, Dict("H"=>12); solar_relative=true)
         @test_throws ArgumentError format_A_X(0.0, Dict(1=>12); solar_relative=true)
 
-        atol = 1e-5
-        @test Korg.get_alpha_H(format_A_X(0.1)) ≈ 0.1 atol=atol
-        @test Korg.get_alpha_H(format_A_X(0.0, 0.1)) ≈ 0.1 atol=atol
-        @test Korg.get_alpha_H(format_A_X(-0.2)) ≈ -0.2 atol=atol
-        @test Korg.get_alpha_H(format_A_X(-2, -0.2)) ≈ -0.2 atol=atol
-        @test Korg.get_metals_H(format_A_X(0.1)) ≈ 0.1 atol=atol
-        @test Korg.get_metals_H(format_A_X(-0.2)) ≈ -0.2 atol=atol
-        @test Korg.get_metals_H(format_A_X(0.1, 0.5)) ≈ 0.1 atol=atol
-        @test Korg.get_metals_H(format_A_X(-0.2, 0.5)) ≈ -0.2 atol=atol
-        @test Korg.get_metals_H(Korg.grevesse_2007_solar_abundances; 
-                                solar_abundances=Korg.grevesse_2007_solar_abundances) ≈ 0 atol=atol
-        @test Korg.get_alpha_H(Korg.grevesse_2007_solar_abundances;
-                               solar_abundances=Korg.grevesse_2007_solar_abundances) ≈ 0 atol=atol
+        @testset "consitency of format_A_X and get_alpha_H/get_metals_H" begin
+            @test Korg.get_alpha_H(format_A_X(0.1)) ≈ 0.1
+            @test Korg.get_alpha_H(format_A_X(0.0, 0.1)) ≈ 0.1
+            @test Korg.get_alpha_H(format_A_X(-0.2)) ≈ -0.2 
+            @test Korg.get_alpha_H(format_A_X(-2, -5)) ≈ -5
+
+            @test Korg.get_metals_H(format_A_X(0.1)) ≈ 0.1
+            @test Korg.get_metals_H(format_A_X(-0.2)) ≈ -0.2
+            @test Korg.get_metals_H(format_A_X(0.1, 0.5)) ≈ 0.1
+            @test Korg.get_metals_H(format_A_X(-0.2, 0.5)) ≈ -0.2
+
+            @test Korg.get_metals_H(Korg.grevesse_2007_solar_abundances; 
+                                    solar_abundances=Korg.grevesse_2007_solar_abundances) ≈ 0 
+            @test Korg.get_alpha_H(Korg.grevesse_2007_solar_abundances;
+                                   solar_abundances=Korg.grevesse_2007_solar_abundances) ≈ 0 
+        end
 
         @test format_A_X(1.1) != format_A_X(1.1, 0)
         @test format_A_X(1.1)[50] == format_A_X(1.1, 0)[50] == format_A_X(-1, -2, Dict(50=>1.1))[50]


### PR DESCRIPTION
This PR does several things:
- implements the specialized interpolation methods for cool dwarfs described in the Korg II paper. (perhaps closing #164)
- closes #258 
- indirectly addresses #290 by making `clamp_abundances=true` the default
- fixes a bug in in the abundance clamping where C and alpha were being mixed up due to a typo
- unifies the behavior of `get_alpha_H` and `format_A_X` to treat C as _not_ an alpha element
- Fixes a stupid missing parens typo/bug affecting `get_metals_H` and `get_alpha_H`.  The problem wasn't numerically obvious (though I still should have noted it) because I wasn't testing the truly low-metallicity regime.
- Tweaks the optimizer params used in `Korg.Fit.fit_spectrum`. This became necessary because the solver's tendency to take huge steps combined catastrophically with the increased allowed metallicity.  Limiting the step size works wonders and seems to be a general improvement (convergence achieved in ~half as many iterations, although first-time compile is longer).  I also tightened the tolerance.

The behavior for metal-poor atmospheres is definitely "good enough" rather than anything I'm particularly proud of.  I filled the many holes in the grid with RBF interpolation and use linear interp to construct the atmospheres.  Abundances are assumed to match the MARCS standard composition (so no varying with alpha and C).  I think this is on par with everything else available, but I would like to do it better eventually.

TODO
- [x] documentation
- [x] test integration with `Korg.Fit`
