### PR TITLE
Clarify carbon/alphas situation

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -371,7 +371,7 @@ See also [`get_alpha_H`](@ref).
   convenience.
 - `ignore_alpha` (default: `true`): Whether or not to ignore the alpha elements when calculating 
   [metals/H].  If `true`, [metals/H] is calculated using all elements heavier than He.  If `false`, 
-  the alpha elements (here defined as C, O, Ne, Mg, Si, S, Ar, Ca, Ti) are ignored.
+  then both carbon and the alpha elements (here defined as O, Ne, Mg, Si, S, Ar, Ca, Ti) are ignored.
 """
 function get_metals_H(A_X; solar_abundances=default_solar_abundances, ignore_alpha=true)
     els = if ignore_alpha


### PR DESCRIPTION
Reword the docstring for `get_metals_h` to be less confusing.

Thanks @svenbuder for pointing this out.  I won't merge this PR until I hear back about whether this behavior is a problem for you.