### PR TITLE
don't fail on atm interp errors when fitting

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -280,7 +280,11 @@ function fit_spectrum(obs_wls, obs_flux, obs_err, linelist, initial_guesses, fix
             flux = try
                 synthetic_spectrum(synthesis_wls, linelist, LSF_matrix, params, synthesis_kwargs)
             catch e
-                if e isa Korg.ChemicalEquilibriumError
+                if (e isa Korg.ChemicalEquilibriumError) || (e isa Korg.LazyMultilinearInterpError)
+                    # chemical equilibrium errors happen for a few unphysical model atmospheres
+
+                    # LazyMultilinearInterpError happens when logg is oob for the low-Z atmosphere grid
+
                     # This is a nice huge chi2 value, but not too big.  It's what you get if 
                     # difference at each pixel in the (rectified) spectra is 1, which is 
                     # more-or-less an upper bound.

--- a/src/lazy_multilinear_interpolation.jl
+++ b/src/lazy_multilinear_interpolation.jl
@@ -1,3 +1,9 @@
+struct LazyMultilinearInterpError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::LazyMultilinearInterpError) = 
+    print(io, "LazyMultilinearInterpError: ", e.msg)
+
 """
     lazy_multilinear_interpolation(params, nodes, grid; kwargs...)
 
@@ -28,7 +34,7 @@ function lazy_multilinear_interpolation(params, nodes, grid;
         if !(p_nodes[1] <= p <= p_nodes[end])
             msg = "Can't interpolate grid.  $(p_name) is out of bounds. ($(p) ∉ [$(first(p_nodes)), $(last(p_nodes))])." * 
                   " If you got the message calling `interpolate_marcs`, consider setting `clamp_abundances=true`."
-            throw(ArgumentError(msg))
+            throw(LazyMultilinearInterpError(msg))
         end
         findfirst(p .<= p_nodes)
     end

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -75,11 +75,10 @@
         @testset "clamping abundances" begin
             m_H_nodes = Korg._sdss_marcs_atmospheres[1][3]
 
-
             atm1 = interpolate_marcs(5000.0, 3.0, 0, -1.0)
 
             A_X = format_A_X(0, -5; solar_abundances=Korg.grevesse_2007_solar_abundances)
-            @test_throws ArgumentError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
+            @test_throws Korg.LazyMultilinearInterpError interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=false)
             atm2 = interpolate_marcs(5000.0, 3.0, A_X; clamp_abundances=true)
 
             @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)


### PR DESCRIPTION
The low-metallicity atmosphere grid stops at $\log g=0.5$ instead of $-0.5$, which means that the fitter can wander into disallowed stellar parameter space. This introduces a special error type for the lazy multilinear interp used for atmosphere interpolation, and catches it to not fail (instead returning a high $\chi^2$ value) during fitting.

This is not the most elegant solution in the world, but it gets the job done.