### PR TITLE
Qfactor calculation contribution

### DIFF
--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -21,6 +21,7 @@ module Korg
     include("synthesize.jl")               # top-level API
     include("prune_linelist.jl")           # select strong lines from a linelist
     include("fit.jl")                      # routines to infer stellar params from data
+    include("qfactors.jl")                 # formalism to compute theoretical RV precision
 
     export synthesize, read_linelist, read_model_atmosphere, interpolate_marcs, format_A_X
 end # module

--- a/src/qfactors.jl
+++ b/src/qfactors.jl
@@ -28,12 +28,12 @@ Compute the Q factor from the high resolution theoretical spectrum, the high res
 - `spec_hres::Vector{Real}`: High resolution theoretical spectrum
 - `wave_hres`: High resolution wavelength grid
 - `wave_lres`: Low resolution wavelength grid
-- `LSF_mat::Matrix{Real}`: LSF matrix
+- `LSF_mat`: LSF matrix
 
 # Keyword Arguments
 - `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
 """
-function Qfactor(spec_hres::Vector{Real},wave_hres,wave_lres,LSF_mat::Matrix{Real}; msk_lres::Vector{Bool}=nothing)
+function Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2) # normalisation for the LSF
     spec_lres = LSF_mat*spec_hres./nvecLSF
 
@@ -58,14 +58,14 @@ Compute the RV precision using the true observed uncertainties on the continuum 
 - `spec_hres::Vector{Real}`: High resolution theoretical spectrum
 - `wave_hres`: High resolution wavelength grid
 - `wave_lres`: Low resolution wavelength grid
-- `LSF_mat::Matrix{Real}`: LSF matrix
+- `LSF_mat`: LSF matrix
 - `noise_contNorm::Vector{Real}`: Noise in the continuum normalized spectrum
 
 # Keyword Arguments
-- `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
+- `msk_lres=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
 - `c::Real=299792458`: Speed of light in m/s
 """
-function precRV_MeasuredNoise(spec_hres::Vector{Real},wave_hres,wave_lres,LSF_mat::Matrix{Real},noise_contNorm::Vector{Real};msk_lres::Vector{Bool}=nothing,c::Real = 299792458)
+function precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm; msk_lres=nothing,c::Real = 299792458)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2)
 
     dspec_dlam = zeros(length(spec_hres))

--- a/src/qfactors.jl
+++ b/src/qfactors.jl
@@ -1,0 +1,37 @@
+## Computation of Q-factors to provide an estimate of the RV precision for a given spectrum as a function of SNR
+
+## Making the approximation that the spectrum as an ``average'' SNR per pixel when estimating the RV precision
+function precRV_fromQ(Q,SNR,Npix;c = 299792458) # c in m/s, SNR per pixel
+    return c/(Q*sqrt(Npix)*SNR)
+end
+
+## Qfactor from the theoreticsl spectrum and LSF model, assuming uniform efficiency as a function of wavelength
+function Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
+    nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2) # normalisation for the LSF
+    spec_lres = LSF_mat*spec_hres./nvecLSF
+
+    dspec_dlam = zeros(length(spec_hres))
+    dspec_dlam[2:end] .= diff(spec_hres)./diff(wave_hres)
+
+    Wvec = ((wave_lres.*(LSF_mat*dspec_dlam)./nvecLSF).^2)./spec_lres
+    if isnothing(msk_lres)
+        return sqrt(sum(Wvec)/sum(spec_lres))
+    else
+        return sqrt(sum(Wvec[msk_lres])/sum(spec_lres[msk_lres]))
+    end
+end
+
+## Theoretical limit on RV precision from the measured noise in the spectrum
+function precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm;msk_lres=nothing,c = 299792458)
+    nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2)
+
+    dspec_dlam = zeros(length(spec_hres))
+    dspec_dlam[2:end] .= diff(spec_hres)./diff(wave_hres)
+
+    Wvec = ((wave_lres.*(LSF_mat*dspec_dlam)./nvecLSF).^2)./(noise_contNorm.^2)
+    if isnothing(msk_lres)
+        return c /sqrt(sum(Wvec))
+    else
+        return c /sqrt(sum(Wvec[msk_lres]))
+    end
+end

--- a/src/qfactors.jl
+++ b/src/qfactors.jl
@@ -1,12 +1,39 @@
 ## Computation of Q-factors to provide an estimate of the RV precision for a given spectrum as a function of SNR
 
 ## Making the approximation that the spectrum as an ``average'' SNR per pixel when estimating the RV precision
-function precRV_fromQ(Q,SNR,Npix;c = 299792458) # c in m/s, SNR per pixel
+"""
+    precRV_fromQ(Q,SNR,Npix;c = 299792458)
+
+Compute the RV precision from the Q factor, the SNR per pixel, and the number of pixels in the spectrum.
+
+# Arguments
+- `Q::Real`: Q factor of the spectrum
+- `SNR::Real`: SNR per pixel of the spectrum
+- `Npix::Real`: Number of pixels in the spectrum
+
+# Keyword Arguments
+- `c::Real=299792458`: Speed of light in m/s
+"""
+function precRV_fromQ(Q::Real,SNR::Real,Npix::Real;c::Real = 299792458) # c in m/s, SNR per pixel
     return c/(Q*sqrt(Npix)*SNR)
 end
 
 ## Qfactor from the theoreticsl spectrum and LSF model, assuming uniform efficiency as a function of wavelength
-function Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
+"""
+    Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
+
+Compute the Q factor from the high resolution theoretical spectrum, the high resolution wavelength grid, the low resolution (observed) wavelength grid, and the LSF matrix.
+
+# Arguments
+- `spec_hres::Vector{Real}`: High resolution theoretical spectrum
+- `wave_hres::Vector{Real}`: High resolution wavelength grid
+- `wave_lres::Vector{Real}`: Low resolution wavelength grid
+- `LSF_mat::Matrix{Real}`: LSF matrix
+
+# Keyword Arguments
+- `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
+"""
+function Qfactor(spec_hres::Vector{Real},wave_hres::Vector{Real},wave_lres::Vector{Real},LSF_mat::Matrix{Real}; msk_lres::Vector{Bool}=nothing)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2) # normalisation for the LSF
     spec_lres = LSF_mat*spec_hres./nvecLSF
 
@@ -22,7 +49,23 @@ function Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
 end
 
 ## Theoretical limit on RV precision from the measured noise in the spectrum
-function precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm;msk_lres=nothing,c = 299792458)
+"""
+    precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm;msk_lres=nothing,c = 299792458)
+
+Compute the RV precision using the true observed uncertainties on the continuum normalized spectrum as a function of wavelength.
+
+# Arguments
+- `spec_hres::Vector{Real}`: High resolution theoretical spectrum
+- `wave_hres::Vector{Real}`: High resolution wavelength grid
+- `wave_lres::Vector{Real}`: Low resolution wavelength grid
+- `LSF_mat::Matrix{Real}`: LSF matrix
+- `noise_contNorm::Vector{Real}`: Noise in the continuum normalized spectrum
+
+# Keyword Arguments
+- `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
+- `c::Real=299792458`: Speed of light in m/s
+"""
+function precRV_MeasuredNoise(spec_hres::Vector{Real},wave_hres::Vector{Real},wave_lres::Vector{Real},LSF_mat::Matrix{Real},noise_contNorm::Vector{Real};msk_lres::Vector{Bool}=nothing,c::Real = 299792458)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2)
 
     dspec_dlam = zeros(length(spec_hres))

--- a/src/qfactors.jl
+++ b/src/qfactors.jl
@@ -26,14 +26,14 @@ Compute the Q factor from the high resolution theoretical spectrum, the high res
 
 # Arguments
 - `spec_hres::Vector{Real}`: High resolution theoretical spectrum
-- `wave_hres::Vector{Real}`: High resolution wavelength grid
-- `wave_lres::Vector{Real}`: Low resolution wavelength grid
+- `wave_hres`: High resolution wavelength grid
+- `wave_lres`: Low resolution wavelength grid
 - `LSF_mat::Matrix{Real}`: LSF matrix
 
 # Keyword Arguments
 - `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
 """
-function Qfactor(spec_hres::Vector{Real},wave_hres::Vector{Real},wave_lres::Vector{Real},LSF_mat::Matrix{Real}; msk_lres::Vector{Bool}=nothing)
+function Qfactor(spec_hres::Vector{Real},wave_hres,wave_lres,LSF_mat::Matrix{Real}; msk_lres::Vector{Bool}=nothing)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2) # normalisation for the LSF
     spec_lres = LSF_mat*spec_hres./nvecLSF
 
@@ -56,8 +56,8 @@ Compute the RV precision using the true observed uncertainties on the continuum 
 
 # Arguments
 - `spec_hres::Vector{Real}`: High resolution theoretical spectrum
-- `wave_hres::Vector{Real}`: High resolution wavelength grid
-- `wave_lres::Vector{Real}`: Low resolution wavelength grid
+- `wave_hres`: High resolution wavelength grid
+- `wave_lres`: Low resolution wavelength grid
 - `LSF_mat::Matrix{Real}`: LSF matrix
 - `noise_contNorm::Vector{Real}`: Noise in the continuum normalized spectrum
 
@@ -65,7 +65,7 @@ Compute the RV precision using the true observed uncertainties on the continuum 
 - `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
 - `c::Real=299792458`: Speed of light in m/s
 """
-function precRV_MeasuredNoise(spec_hres::Vector{Real},wave_hres::Vector{Real},wave_lres::Vector{Real},LSF_mat::Matrix{Real},noise_contNorm::Vector{Real};msk_lres::Vector{Bool}=nothing,c::Real = 299792458)
+function precRV_MeasuredNoise(spec_hres::Vector{Real},wave_hres,wave_lres,LSF_mat::Matrix{Real},noise_contNorm::Vector{Real};msk_lres::Vector{Bool}=nothing,c::Real = 299792458)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2)
 
     dspec_dlam = zeros(length(spec_hres))

--- a/src/qfactors.jl
+++ b/src/qfactors.jl
@@ -2,7 +2,7 @@
 
 ## Making the approximation that the spectrum as an ``average'' SNR per pixel when estimating the RV precision
 """
-    precRV_fromQ(Q,SNR,Npix;c = 299792458)
+    RV_prec_from_Q(Q,SNR,Npix)
 
 Compute the RV precision from the Q factor, the SNR per pixel, and the number of pixels in the spectrum.
 
@@ -11,36 +11,39 @@ Compute the RV precision from the Q factor, the SNR per pixel, and the number of
 - `SNR::Real`: SNR per pixel of the spectrum
 - `Npix::Real`: Number of pixels in the spectrum
 
-# Keyword Arguments
-- `c::Real=299792458`: Speed of light in m/s
+See also: `Qfactor` and `RV_prec_from_noise`
 """
-function precRV_fromQ(Q::Real,SNR::Real,Npix::Real;c::Real = 299792458) # c in m/s, SNR per pixel
-    return c/(Q*sqrt(Npix)*SNR)
+function RV_prec_from_Q(Q::Real,SNR::Real,Npix::Real)
+    return (Korg.c_cgs*1e-2)/(Q*sqrt(Npix)*SNR)
 end
 
 ## Qfactor from the theoreticsl spectrum and LSF model, assuming uniform efficiency as a function of wavelength
 """
-    Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
+    Qfactor(synth_flux,synth_wl,obs_wl,LSF_mat; msk_lres=nothing)
 
 Compute the Q factor from the high resolution theoretical spectrum, the high resolution wavelength grid, the low resolution (observed) wavelength grid, and the LSF matrix.
 
+Based on work from [Bouchy et al. 2001, A&A, 374, 733](https://ui.adsabs.harvard.edu/abs/2001A%26A...374..733B/abstract).
+
 # Arguments
-- `spec_hres::Vector{Real}`: High resolution theoretical spectrum
-- `wave_hres`: High resolution wavelength grid
-- `wave_lres`: Low resolution wavelength grid
+- `synth_flux::Vector{Real}`: High resolution theoretical spectrum
+- `synth_wl`: High resolution wavelength grid
+- `obs_wl`: Low resolution wavelength grid
 - `LSF_mat`: LSF matrix
 
 # Keyword Arguments
 - `msk_lres::Vector{Bool}=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
+
+See also: `RV_prec_from_Q` and `RV_prec_from_noise`
 """
-function Qfactor(spec_hres,wave_hres,wave_lres,LSF_mat; msk_lres=nothing)
+function Qfactor(synth_flux,synth_wl,obs_wl,LSF_mat; msk_lres=nothing)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2) # normalisation for the LSF
-    spec_lres = LSF_mat*spec_hres./nvecLSF
+    spec_lres = LSF_mat*synth_flux./nvecLSF
 
-    dspec_dlam = zeros(length(spec_hres))
-    dspec_dlam[2:end] .= diff(spec_hres)./diff(wave_hres)
+    dspec_dlam = zeros(length(synth_flux))
+    dspec_dlam[2:end] .= diff(synth_flux)./diff(synth_wl)
 
-    Wvec = ((wave_lres.*(LSF_mat*dspec_dlam)./nvecLSF).^2)./spec_lres
+    Wvec = ((obs_wl.*(LSF_mat*dspec_dlam)./nvecLSF).^2)./spec_lres
     if isnothing(msk_lres)
         return sqrt(sum(Wvec)/sum(spec_lres))
     else
@@ -50,7 +53,7 @@ end
 
 ## Theoretical limit on RV precision from the measured noise in the spectrum
 """
-    precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm;msk_lres=nothing,c = 299792458)
+    RV_prec_from_noise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm;msk_lres=nothing)
 
 Compute the RV precision using the true observed uncertainties on the continuum normalized spectrum as a function of wavelength.
 
@@ -63,9 +66,10 @@ Compute the RV precision using the true observed uncertainties on the continuum 
 
 # Keyword Arguments
 - `msk_lres=nothing`: Mask for the low resolution spectrum to account for pixels masked from the observation
-- `c::Real=299792458`: Speed of light in m/s
+
+See also: `RV_prec_from_Q` and `Qfactor`
 """
-function precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm; msk_lres=nothing,c::Real = 299792458)
+function RV_prec_from_noise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNorm; msk_lres=nothing)
     nvecLSF = dropdims(sum(LSF_mat,dims=2),dims=2)
 
     dspec_dlam = zeros(length(spec_hres))
@@ -73,8 +77,8 @@ function precRV_MeasuredNoise(spec_hres,wave_hres,wave_lres,LSF_mat,noise_contNo
 
     Wvec = ((wave_lres.*(LSF_mat*dspec_dlam)./nvecLSF).^2)./(noise_contNorm.^2)
     if isnothing(msk_lres)
-        return c /sqrt(sum(Wvec))
+        return (Korg.c_cgs*1e-2) /sqrt(sum(Wvec))
     else
-        return c /sqrt(sum(Wvec[msk_lres]))
+        return (Korg.c_cgs*1e-2) /sqrt(sum(Wvec[msk_lres]))
     end
 end

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -1,6 +1,6 @@
 @testset "qfactors" begin
     # Check a Q factor gives the right RV precision
-    @test Korg.precRV_fromQ(1100,100,8000) ≈ 30.470741601352298 atol=1e-10
+    @test Korg.RV_prec_from_Q(1100,100,8000) ≈ 30.470741601352298 atol=1e-10
 
     # Check that a solar spectrum at APOGEE resolution gives the expected Q factor
     delLog = 6e-6; 
@@ -24,7 +24,7 @@
     msk = ones(Bool,length(wavetarg))
     msk[1:100].=false
     msk[end-100:100].=true
-    @test Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk) ≈ 29.490659698846365 atol=1e-10
-    @test Korg.precRV_fromQ(Q,100,count(msk)) ≈ 27.34006821159959 atol=1e-10
+    @test Korg.RV_prec_from_noise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk) ≈ 29.490659698846365 atol=1e-10
+    @test Korg.RV_prec_from_Q(Q,100,count(msk)) ≈ 27.34006821159959 atol=1e-10
     # I think these two should agree... but the problem must be from the continuum defintion and how that propagates to S/N
 end

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -1,6 +1,6 @@
 @testset "qfactors" begin
     # Check a Q factor gives the right RV precision
-    @test abs(Korg.precRV_fromQ(1100,100,8000)-30.470741601352298) < 1e-10
+    @test Korg.precRV_fromQ(1100,100,8000) ≈ 30.470741601352298 atol=1e-10
 
     # Check that a solar spectrum at APOGEE resolution gives the expected Q factor
     delLog = 6e-6; 
@@ -19,12 +19,12 @@
     kout = synthesize(atm, apolines, A_X, wl_lo, wl_hi, wl_step, vmic=0, hydrogen_lines=true, hydrogen_line_window_size=300, electron_number_density_warn_threshold=1e10);
     tspec = (kout.flux)./(kout.cntm);
     Q = Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)
-    @test abs(Q-1182.420317367743)<1e-10
+    @test Q ≈ 1182.420317367743 atol=1e-10
 
     msk = ones(Bool,length(wavetarg))
     msk[1:100].=false
     msk[end-100:100].=true
-    @test abs(Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)-29.490659698846365)<1e-10
-    @test abs(Korg.precRV_fromQ(Q,100,count(msk)).-27.34006821159959)<1e-10
+    @test Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk) ≈ 29.490659698846365 atol=1e-10
+    @test Korg.precRV_fromQ(Q,100,count(msk)) ≈ 27.34006821159959 atol=1e-10
     # I think these two should agree... but the problem must be from the continuum defintion and how that propagates to S/N
 end

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -18,13 +18,13 @@
     atm = Korg.interpolate_marcs(5777, 4.4, Korg.grevesse_2007_solar_abundances)
     kout = synthesize(atm, apolines, A_X, wl_lo, wl_hi, wl_step, vmic=0, hydrogen_lines=true, hydrogen_line_window_size=300, electron_number_density_warn_threshold=1e10);
     tspec = (kout.flux)./(kout.cntm);
-    @test abs(Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)-1182.420317367743)<1e-10
+    Q = Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)
+    @test abs(Q-1182.420317367743)<1e-10
 
     msk = ones(Bool,length(wavetarg))
     msk[1:100].=false
     msk[end-100:100].=true
-    RV_prec = Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)
-    @test abs(RV_prec-29.490659698846365)<1e-10
+    @test abs(Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)-29.490659698846365)<1e-10
     @test abs(Korg.precRV_fromQ(Q,100,count(msk)).-27.34006821159959)<1e-10
     # I think these two should agree... but the problem must be from the continuum defintion and how that propagates to S/N
 end

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -18,8 +18,7 @@
     atm = Korg.interpolate_marcs(5777, 4.4, Korg.grevesse_2007_solar_abundances)
     kout = synthesize(atm, apolines, A_X, wl_lo, wl_hi, wl_step, vmic=0, hydrogen_lines=true, hydrogen_line_window_size=300, electron_number_density_warn_threshold=1e10);
     tspec = (kout.flux)./(kout.cntm);
-    Q = Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)
-    @test abs(Q-1182.420317367743)<1e-10
+    @test abs(Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)-1182.420317367743)<1e-10
 
     msk = ones(Bool,length(wavetarg))
     msk[1:100].=false

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -1,6 +1,6 @@
 @testset "qfactors" begin
     # Check a Q factor gives the right RV precision
-    @test abs(precRV_fromQ(1100,100,8000)-30.470741601352298) < 1e-10
+    @test abs(Korg.precRV_fromQ(1100,100,8000)-30.470741601352298) < 1e-10
 
     # Check that a solar spectrum at APOGEE resolution gives the expected Q factor
     delLog = 6e-6; 
@@ -18,14 +18,14 @@
     atm = Korg.interpolate_marcs(5777, 4.4, Korg.grevesse_2007_solar_abundances)
     kout = synthesize(atm, apolines, A_X, wl_lo, wl_hi, wl_step, vmic=0, hydrogen_lines=true, hydrogen_line_window_size=300, electron_number_density_warn_threshold=1e10);
     tspec = (kout.flux)./(kout.cntm);
-    Q = Qfactor(tspec, x_model, wavetarg, LSF_model)
+    Q = Korg.Qfactor(tspec, x_model, wavetarg, LSF_model)
     @test abs(Q-1182.420317367743)<1e-10
 
     msk = ones(Bool,length(wavetarg))
     msk[1:100].=false
     msk[end-100:100].=true
-    RV_prec = precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)
+    RV_prec = Korg.precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)
     @test abs(RV_prec-29.490659698846365)<1e-10
-    @test abs(precRV_fromQ(Q,100,count(msk)).-27.34006821159959)<1e-10
+    @test abs(Korg.precRV_fromQ(Q,100,count(msk)).-27.34006821159959)<1e-10
     # I think these two should agree... but the problem must be from the continuum defintion and how that propagates to S/N
 end

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -1,0 +1,31 @@
+@testset "qfactors" begin
+    # Check a Q factor gives the right RV precision
+    @test abs(precRV_fromQ(1100,100,8000)-30.470741601352298) < 1e-10
+
+    # Check that a solar spectrum at APOGEE resolution gives the expected Q factor
+    delLog = 6e-6; 
+    wavetarg = 10 .^range((start=4.179-125*delLog),step=delLog,length=8575+125)
+    minw, maxw = extrema(wavetarg);
+    
+    wl_lo, wl_hi, wl_step = 15_000, 17_000, 1//100
+    x_model = wl_lo:wl_step:wl_hi
+
+    LSF_model = Korg.compute_LSF_matrix(x_model, wavetarg, 22_500, renormalize_edge=true, verbose=false)
+
+    apolines = Korg.get_APOGEE_DR17_linelist(include_water=true);
+
+    A_X = copy(Korg.grevesse_2007_solar_abundances)
+    atm = Korg.interpolate_marcs(5777, 4.4, Korg.grevesse_2007_solar_abundances)
+    kout = synthesize(atm, apolines, A_X, wl_lo, wl_hi, wl_step, vmic=0, hydrogen_lines=true, hydrogen_line_window_size=300, electron_number_density_warn_threshold=1e10);
+    tspec = (kout.flux)./(kout.cntm);
+    Q = Qfactor(tspec, x_model, wavetarg, LSF_model)
+    @test abs(Q-1182.420317367743)<1e-10
+
+    msk = ones(Bool,length(wavetarg))
+    msk[1:100].=false
+    msk[end-100:100].=true
+    RV_prec = precRV_MeasuredNoise(tspec, x_model, wavetarg, LSF_model, 1 ./100*ones(length(wavetarg)),msk_lres=msk)
+    @test abs(RV_prec-29.490659698846365)<1e-10
+    @test abs(precRV_fromQ(Q,100,count(msk)).-27.34006821159959)<1e-10
+    # I think these two should agree... but the problem must be from the continuum defintion and how that propagates to S/N
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,6 @@ include("synthesize.jl")
 include("prune_linelist.jl")
 include("utils.jl")
 include("line_absorption.jl")
-
+include("qfactors.jl")
 
 end #top-level testset


### PR DESCRIPTION
This PR is tracking the contribution of methods of computing theoretical lower bounds on RV precision (different levels of approximation of the so-called Q-factor from Bouchy 2001). 

Happy to have feedback on code style etc. I plan to improve the function documentation. 

Currently, I am unhappy that the last two tests are not equal to eachother, because I was trying to compute the lower bound using the more rigorous function under the conditions that would make the approximation used in the second test true. I think the issue lies in the definition of the continuum and how it is interplaying with the S/N. The difference is only 2 m/s... but I will still run down.