### PR TITLE
Atm interp error when interpolated parameters are all `Int`s

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -323,6 +323,6 @@ function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg <
         end
     end
 end
-# handle the case where Teff is an integer. As long as not all params are passed in as integers, 
-# there's no problem. 
-interpolate_marcs(Teff::Int, args...; kwargs...) = interpolate_marcs(Float64(Teff), args...; kwargs...)
+# handle the case where Teff, logg, and [m/H] are integers. As long as not all (interpolated) params 
+# are passed in as integers, there's no problem. 
+interpolate_marcs(Teff::Int, logg::Int, m_H::Int, args...; kwargs...) = interpolate_marcs(Float64(Teff), args...; kwargs...)

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -275,6 +275,7 @@ end
 function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg < 3.5, 
                            perturb_at_grid_values=true, resampled_cubic_for_cool_dwarfs=true,
                            archives=(_sdss_marcs_atmospheres, _cool_dwarfs_atm_itp, _low_Z_marcs_atmospheres))
+    # cool dwarfs
     if Teff <= 4000 && logg >= 3.5 && m_H >= -2.5 && resampled_cubic_for_cool_dwarfs
         itp, nlayers = archives[2]
         atm_quants = itp(1:nlayers, 1:5, Teff, logg, m_H, alpha_m, C_m)
@@ -285,6 +286,7 @@ function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg <
             exp.(atm_quants[:, 2]), 
             exp.(atm_quants[:, 3])))
     else
+        # low metallicity
         if m_H < -2.5
             nodes, grid = archives[3]
             if alpha_m != 0.4 || C_m != 0
@@ -292,6 +294,7 @@ function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg <
             end
             params = [Teff, logg, m_H]
             param_names = ["Teff", "log(g)", "[M/H]"]
+        # standard 
         else
             nodes, grid = archives[1]
             params = [Teff, logg, m_H, alpha_m, C_m]
@@ -320,3 +323,6 @@ function interpolate_marcs(Teff, logg, m_H=0, alpha_m=0, C_m=0; spherical=logg <
         end
     end
 end
+# handle the case where Teff is an integer. As long as not all params are passed in as integers, 
+# there's no problem. 
+interpolate_marcs(Teff::Int, args...; kwargs...) = interpolate_marcs(Float64(Teff), args...; kwargs...)

--- a/test/atmosphere.jl
+++ b/test/atmosphere.jl
@@ -109,8 +109,8 @@
 
         @testset "low-metallicity" begin
             δ = 1e-3
-            atm1 = interpolate_marcs(5000.0, 4.5, -2.5+δ, 0.4)
-            atm2 = interpolate_marcs(5000.0, 4.5, -2.5-δ, 0.4)
+            atm1 = interpolate_marcs(5000, 4.5, -2.5+δ, 0.4)
+            atm2 = interpolate_marcs(5000, 4.5, -2.5-δ, 0.4)
             @test assert_atmospheres_close(atm1, atm2; rtol=1e-2)
 
             # set up A_X with abundances that don't match the MARCS standard comp
@@ -120,6 +120,18 @@
             @test assert_atmospheres_close(atm2, atm3; rtol=1e-10)
 
             @test_throws ArgumentError interpolate_marcs(5000, 4.5, -3, 0)
+        end
+
+
+        @testset "integer arguments" begin
+            # make sure it doesn't crash when it's all integers
+
+            # low metallicity
+            @test interpolate_marcs(5000, 1,-3, 0.4,0) isa Korg.ModelAtmosphere
+            # standard
+            @test interpolate_marcs(5000, 1, -1, 0,0) isa Korg.ModelAtmosphere
+            # cool dwarf
+            @test interpolate_marcs(5000, 1,-3, 0.4,0) isa Korg.ModelAtmosphere
         end
     end
 end


### PR DESCRIPTION
This fixes the bug in #318 and introduces a test which would have caught it.