### PR TITLE
Fix molecular sigmas when read from file

### DIFF
--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -72,7 +72,6 @@ function MolecularCrossSection(linelist, wl_params...; cutoff_alpha=1e-32,
     MolecularCrossSection(wl_ranges, itp, species)
 end
 
-#TODO make sure this works
 function Base.show(io::IO, ::MIME"text/plain", sigma::MolecularCrossSection)
     println(io, "Molecular cross-section for ", sigma.species,
             " ($(sigma.wls[1]) Å ≤ λ ≤ $(sigma.wls[end]) Å)")

--- a/test/molecular_cross_sections.jl
+++ b/test/molecular_cross_sections.jl
@@ -16,18 +16,19 @@
 
     atm = interpolate_marcs(4000.0, 4.5)
 
-    @testset for vmic in [0.5, 2.5]
-        sol_without = synthesize(atm, linelist, format_A_X(), wls; verbose=false, vmic=vmic)
-        sol_with = synthesize(atm, linelist_less_water, format_A_X(), wls;
-                              molecular_cross_sections=[table], verbose=false, vmic=vmic)
-
-        @test assert_allclose(sol_without.flux, sol_with.flux; rtol=1e-3)
-    end
-
     filename = tempname()
     Korg.save_molecular_cross_section(filename, table)
     deserialized_table = Korg.read_molecular_cross_section(filename)
     @test table.itp.itp.coefs == deserialized_table.itp.itp.coefs
     @test all(table.wls .== deserialized_table.wls)
     @test table.species == deserialized_table.species
+
+    @testset for vmic in [0.5, 2.5]
+        sol_without = synthesize(atm, linelist, format_A_X(), wls; verbose=false, vmic=vmic)
+        sol_with = synthesize(atm, linelist_less_water, format_A_X(), wls;
+                              molecular_cross_sections=[deserialized_table], verbose=false,
+                              vmic=vmic)
+
+        @test assert_allclose(sol_without.flux, sol_with.flux; rtol=1e-3)
+    end
 end


### PR DESCRIPTION
Fixes a unit bug introduced in #313 that results in pretabulated molecular cross sections doing nothing when read from a file.