### PR TITLE
Lazy dwarf atm (faster precompile)

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -193,15 +193,15 @@ function _prepare_cool_dwarf_atm_archive(grid, nodes)
 
     # This currently add a lot of time to package precompile time if not done lazily.  
     # Ideally it would be faster.
-    @time itp = Interpolations.scale(Interpolations.interpolate(grid,
-                                                                (Interpolations.NoInterp(),
-                                                                 Interpolations.NoInterp(),
-                                                                 Interpolations.BSpline(Interpolations.Cubic()),
-                                                                 Interpolations.BSpline(Interpolations.Cubic()),
-                                                                 Interpolations.BSpline(Interpolations.Cubic()),
-                                                                 Interpolations.BSpline(Interpolations.Cubic()),
-                                                                 Interpolations.BSpline(Interpolations.Cubic()))),
-                                     knots)
+    itp = Interpolations.scale(Interpolations.interpolate(grid,
+                                                          (Interpolations.NoInterp(),
+                                                           Interpolations.NoInterp(),
+                                                           Interpolations.BSpline(Interpolations.Cubic()),
+                                                           Interpolations.BSpline(Interpolations.Cubic()),
+                                                           Interpolations.BSpline(Interpolations.Cubic()),
+                                                           Interpolations.BSpline(Interpolations.Cubic()),
+                                                           Interpolations.BSpline(Interpolations.Cubic()))),
+                               knots)
     itp, nlayers
 end
 _cool_dwarfs_atm_itp = nothing
@@ -214,7 +214,7 @@ function _get_cool_dwarfs_atm_itp()
         grid, nodes = h5open(path, "r") do f
             read(f["grid"]), [read(f["grid_values/$i"]) for i in 1:5]
         end
-        _prepare_cool_dwarf_atm_archive(grid, nodes)
+        global _cool_dwarfs_atm_itp = _prepare_cool_dwarf_atm_archive(grid, nodes)
     end
     _cool_dwarfs_atm_itp
 end


### PR DESCRIPTION
Construct the dwarf atmosphere interpolator only when needed for the first time (which will never happen in many Korg sessions.)

This cuts ~1min from the precompilation time, which has been starting to annoy me.  It slightly shifts time from precompilation to TTFX for end users doing specific things, but I think the tradeoff is worth it.

Better solution is just to make this bit not slow.