### PR TITLE
faster, pruned, GES linelist

### DIFF
--- a/data/linelists/GES/save_pruned_GES_linelist.jl
+++ b/data/linelists/GES/save_pruned_GES_linelist.jl
@@ -1,0 +1,19 @@
+using Korg
+
+linelist = Korg.get_GES_linelist()
+
+all_pruned = map([(6000, 4), (3000, 5), (4000, 3.5)]) do (Teff, logg)
+    atm = interpolate_marcs(Teff, logg, A_X)
+    Korg.prune_linelist(atm, linelist, A_X, wls; threshold=1e-4, sort_by_EW=false)
+end
+
+A_X = format_A_X()
+wls = Korg.Wavelengths(linelist[1].wl, linelist[end].wl)
+
+all_pruned = map([(6000, 4), (3000, 5), (4000, 3.5)]) do (Teff, logg)
+    atm = interpolate_marcs(Teff, logg, A_X)
+    Korg.prune_linelist(atm, linelist, A_X, wls; threshold=1e-4, sort_by_EW=false)
+end
+
+pruned = sort(unique([all_pruned...;]); by=l -> l.wl)
+println(length(pruned) / length(linelist), " of the GES linelist was retained.")

--- a/data/linelists/GES/save_pruned_GES_linelist.jl
+++ b/data/linelists/GES/save_pruned_GES_linelist.jl
@@ -1,19 +1,30 @@
 using Korg
 
 linelist = Korg.get_GES_linelist()
-
-all_pruned = map([(6000, 4), (3000, 5), (4000, 3.5)]) do (Teff, logg)
-    atm = interpolate_marcs(Teff, logg, A_X)
-    Korg.prune_linelist(atm, linelist, A_X, wls; threshold=1e-4, sort_by_EW=false)
-end
-
 A_X = format_A_X()
+teff_loggs = [(6000, 4), (3000, 5), (4000, 2)]
+atms = map(teff_loggs) do (Teff, logg)
+    interpolate_marcs(Teff, logg, A_X)
+end
 wls = Korg.Wavelengths(linelist[1].wl, linelist[end].wl)
 
-all_pruned = map([(6000, 4), (3000, 5), (4000, 3.5)]) do (Teff, logg)
-    atm = interpolate_marcs(Teff, logg, A_X)
-    Korg.prune_linelist(atm, linelist, A_X, wls; threshold=1e-4, sort_by_EW=false)
+all_pruned = map(atms) do atm
+    @time Korg.prune_linelist(atm, linelist, A_X, wls;
+                              threshold=1e-6, sort_by_EW=false, max_distance=10)
 end
 
 pruned = sort(unique([all_pruned...;]); by=l -> l.wl)
 println(length(pruned) / length(linelist), " of the GES linelist was retained.")
+
+using PyPlot
+
+map(atms, teff_loggs) do atm, (Teff, logg)
+    figure(; figsize=(12, 5))
+    @time spec1 = synthesize(atm, linelist, A_X, wls)
+    @time spec = synthesize(atm, pruned, A_X, wls)
+    title("Teff = $Teff, logg = $logg")
+    plot(spec.wavelengths, (spec.flux - spec1.flux) ./ spec.cntm)
+    ylabel("rect flux residuals")
+    xlabel("Wavelength (Å)")
+    savefig("GES_pruned_T_$(Teff)_logg_$(logg).png")
+end


### PR DESCRIPTION
This script produces a linelist that is slightly over-pruned.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/205d3906-393f-43f7-a090-963b1d0f7b1c">

Flux difference at Teff=4000k, logg=3.5, solar abundances:
![image](https://github.com/user-attachments/assets/0c72b7e0-a268-4a39-a856-8549db54ec2e)

TODO
- make less agressive 
- test