### PR TITLE
Linelist serialization

### DIFF
--- a/src/Korg.jl
+++ b/src/Korg.jl
@@ -26,9 +26,9 @@ include("prune_linelist.jl")           # select strong lines from a linelist
 include("fit.jl")                      # routines to infer stellar params from data
 include("qfactors.jl")                 # formalism to compute theoretical RV precision
 
-@compat public get_APOGEE_DR17_linelist, get_GALAH_DR3_linelist, get_GES_linelist, Fit, apply_LSF,
-               compute_LSF_matrix, air_to_vacuum, vacuum_to_air, line_profile, blackbody,
-               prune_linelist, merge_close_lines, Line
+@compat public get_APOGEE_DR17_linelist, get_GALAH_DR3_linelist, get_GES_linelist, save_linelist,
+               Fit, apply_LSF, compute_LSF_matrix, air_to_vacuum, vacuum_to_air, line_profile,
+               blackbody, prune_linelist, merge_close_lines, Line
 export synthesize, read_linelist, read_model_atmosphere, interpolate_marcs,
        format_A_X
 end # module

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -629,6 +629,7 @@ set to 0.01.  It was downloaded on 2021-05-20. It is intended to be used for qui
 """
 get_VALD_solar_linelist() = read_linelist(joinpath(_data_dir, "linelists",
                                                    "vald_extract_stellar_solar_threshold001.vald"))
+# this should be rewritten to use save_linelist and read_linelist
 
 """
     get_APOGEE_DR17_linelist(; include_water=true)
@@ -638,6 +639,7 @@ nearly the same at the DR 16 linelist described in
 [Smith+ 2021](https://ui.adsabs.harvard.edu/abs/2021AJ....161..254S/abstract).
 """
 function get_APOGEE_DR17_linelist(; include_water=true)
+    # this should be rewritten to use save_linelist and read_linelist
     dir = joinpath(_data_dir, "linelists", "APOGEE_DR17")
 
     atoms = read_linelist(joinpath(dir, "turbospec.20180901t20.atoms_no_ba");
@@ -671,6 +673,7 @@ See [Buder et al. 2021](https://ui.adsabs.harvard.edu/abs/2021MNRAS.506..150B%2F
 details.
 """
 function get_GALAH_DR3_linelist()
+    # this should be rewritten to use save_linelist and read_linelist
     path = joinpath(_data_dir, "linelists", "GALAH_DR3", "galah_dr3_linelist.h5")
     h5open(path, "r") do f
         species = map(eachcol(read(f["formula"])), read(f["ionization"])) do atoms, ion
@@ -710,6 +713,7 @@ don't need molecular lines, you can set `include_molecules=false` to speed thing
   - `include_molecules` (default: `true`): whether to include molecular lines.
 """
 function get_GES_linelist(; include_molecules=true)
+    # this should be rewritten to use save_linelist and read_linelist
     path = joinpath(artifact"Heiter_2021_GES_linelist",
                     "Heiter_et_al_2021_2022_06_17",
                     "Heiter_et_al_2021.h5")
@@ -746,6 +750,7 @@ This linelist loaded into `Korg._alpha_5000_default_linelist` when Korg is impor
 """
 function _load_alpha_5000_linelist(path=joinpath(_data_dir, "linelists", "alpha_5000",
                                                  "alpha_5000_lines.csv"))
+    # this should be rewritten to use save_linelist and read_linelist
     csv = CSV.File(path)
     map(csv) do row
         vdW = if ',' in row.vdW

--- a/test/linelist.jl
+++ b/test/linelist.jl
@@ -17,6 +17,11 @@
             # make sure things run (types have caused problems in the past)
             λ = linelist[1].wl * 1e8
             synthesize(atm, linelist, format_A_X(), λ, λ)
+
+            filename = tempname() * ".h5"
+            Korg.save_linelist(filename, linelist)
+            linelist2 = read_linelist(filename)
+            @test linelist == linelist2
         end
     end
 
@@ -179,7 +184,7 @@
 
         vac_ll = read_linelist("data/linelists/Turbospectrum/goodlist"; format="turbospectrum_vac")
         for (l_air, l_vac) in zip(ll, vac_ll)
-            # l_vac.wl is "really" an air wavelength, but it wasn't converted because we told Korg 
+            # l_vac.wl is "really" an air wavelength, but it wasn't converted because we told Korg
             # to read it in as vacuum
             @test l_air.wl≈Korg.air_to_vacuum(l_vac.wl) rtol=1e-8
         end

--- a/test/linelist.jl
+++ b/test/linelist.jl
@@ -18,10 +18,11 @@
             λ = linelist[1].wl * 1e8
             synthesize(atm, linelist, format_A_X(), λ, λ)
 
+            # test saving and loading
             filename = tempname() * ".h5"
-            Korg.save_linelist(filename, linelist)
+            Korg.save_linelist(filename, linelist[1:1000])
             linelist2 = read_linelist(filename)
-            @test linelist == linelist2
+            @test linelist[1:1000] == linelist2
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,26 +5,26 @@ using Korg, Test, Logging, HDF5, ForwardDiff, FiniteDiff, Aqua
     # tools for testing: assert_allclose and assert_allclose_grid
     include("utilities.jl")
 
-    #include("wavelengths.jl")
-    #include("molecular_cross_sections.jl")
-    #include("cubic_splines.jl")
-    #include("transfer.jl")
-    #include("species.jl")
-    #include("interval.jl")
-    #include("continuum_absorption.jl") # test this after the "Interval" testset
-    #include("partition_funcs.jl")
-    #include("statmech.jl")
+    include("wavelengths.jl")
+    include("molecular_cross_sections.jl")
+    include("cubic_splines.jl")
+    include("transfer.jl")
+    include("species.jl")
+    include("interval.jl")
+    include("continuum_absorption.jl") # test this after the "Interval" testset
+    include("partition_funcs.jl")
+    include("statmech.jl")
     include("linelist.jl")
-    #include("fit.jl")                            # slow
-    #include("autodiff.jl")                       # slow
-    #include("autodiffable_conv.jl")
-    #include("atmosphere.jl")                     # slow
-    #include("abundances.jl")
-    #include("synthesize.jl")
-    #include("prune_linelist.jl")
-    #include("utils.jl")
-    #include("line_absorption.jl")
-    #include("qfactors.jl")
+    include("fit.jl")                            # slow
+    include("autodiff.jl")                       # slow
+    include("autodiffable_conv.jl")
+    include("atmosphere.jl")                     # slow
+    include("abundances.jl")
+    include("synthesize.jl")
+    include("prune_linelist.jl")
+    include("utils.jl")
+    include("line_absorption.jl")
+    include("qfactors.jl")
     @testset "Aqua automated checks" begin
         # see https://github.com/JuliaTesting/Aqua.jl/issues/77 for why I'm doing it this way,
         # (basically the default bahavior is different and this is what we want to avoid errors in

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,26 +5,26 @@ using Korg, Test, Logging, HDF5, ForwardDiff, FiniteDiff, Aqua
     # tools for testing: assert_allclose and assert_allclose_grid
     include("utilities.jl")
 
-    include("wavelengths.jl")
-    include("molecular_cross_sections.jl")
-    include("cubic_splines.jl")
-    include("transfer.jl")
-    include("species.jl")
-    include("interval.jl")
-    include("continuum_absorption.jl") # test this after the "Interval" testset
-    include("partition_funcs.jl")
-    include("statmech.jl")
+    #include("wavelengths.jl")
+    #include("molecular_cross_sections.jl")
+    #include("cubic_splines.jl")
+    #include("transfer.jl")
+    #include("species.jl")
+    #include("interval.jl")
+    #include("continuum_absorption.jl") # test this after the "Interval" testset
+    #include("partition_funcs.jl")
+    #include("statmech.jl")
     include("linelist.jl")
-    include("fit.jl")                            # slow
-    include("autodiff.jl")                       # slow
-    include("autodiffable_conv.jl")
-    include("atmosphere.jl")                     # slow
-    include("abundances.jl")
-    include("synthesize.jl")
-    include("prune_linelist.jl")
-    include("utils.jl")
-    include("line_absorption.jl")
-    include("qfactors.jl")
+    #include("fit.jl")                            # slow
+    #include("autodiff.jl")                       # slow
+    #include("autodiffable_conv.jl")
+    #include("atmosphere.jl")                     # slow
+    #include("abundances.jl")
+    #include("synthesize.jl")
+    #include("prune_linelist.jl")
+    #include("utils.jl")
+    #include("line_absorption.jl")
+    #include("qfactors.jl")
     @testset "Aqua automated checks" begin
         # see https://github.com/JuliaTesting/Aqua.jl/issues/77 for why I'm doing it this way,
         # (basically the default bahavior is different and this is what we want to avoid errors in


### PR DESCRIPTION
This adds functionality to save Korg linelists as well-documented HDF5 files which can be re-loaded with `read_linelist`.

The built-in linelists (there are 4 as of today) should be switched over to this system, but they currently work fine, so it can be done as they need to be fixed/modified.