### PR TITLE
LSF edge effects

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,19 +38,23 @@ function merge_bounds(bounds, merge_distance=0.0)
     new_bounds, indices
 end
 
-# used by apply_LSF and compute_LSF_matrix
-# handle case where R is wavelength independent
-function line_spread_function_core!(out, factor, synth_wls::Wavelengths, λ0, R::Real, window_size)
-    σ = λ0 / R / (2sqrt(2log(2))) # convert Δλ = λ0/R (FWHM) to sigma
+# Convert R to a value based on its type
+# used in `_lsf_bounds_and_kernel`
+_resolve_R(R::Real, λ0) = R
+_resolve_R(R::Function, λ0) = R(λ0 * 1e8)  # R is a function of λ in Å
+
+# Core LSF calculation shared by all variants
+function _lsf_bounds_and_kernel(synth_wls::Wavelengths, λ0, R, window_size)
+    R_val = _resolve_R(R, λ0)
+    σ = λ0 / R_val / (2sqrt(2log(2))) # convert Δλ = λ0/R (FWHM) to sigma
+
+    # Calculate bounds and kernel
     lb = searchsortedfirst(synth_wls, λ0 - window_size * σ)
     ub = searchsortedlast(synth_wls, λ0 + window_size * σ)
     @views ϕ = normal_pdf.(synth_wls[lb:ub] .- λ0, σ)
-    out[lb:ub] .+= factor * ϕ ./ sum(ϕ)
-end
-# handle case where R is a function of wavelength
-function line_spread_function_core!(out, factor, synth_wls::Wavelengths, λ0, R, window_size)
-    # λ0 should have been converted to cm by the caller, but R is a function of λ in Å
-    line_spread_function_core!(out, factor, synth_wls, λ0, R(λ0 * 1e8), window_size)
+    normalized_ϕ = ϕ ./ sum(ϕ)
+
+    lb, ub, normalized_ϕ
 end
 
 """
@@ -86,7 +90,8 @@ function apply_LSF(flux::AbstractVector{F}, wls, R; window_size=4) where F<:Real
     convF = zeros(F, length(flux))
     for i in eachindex(wls)
         λ0 = wls[i]
-        line_spread_function_core!(convF, flux[i], wls, λ0, R, window_size)
+        lb, ub, normalized_ϕ = _lsf_bounds_and_kernel(wls, λ0, R, window_size)
+        convF[i] = sum(flux[lb:ub] .* normalized_ϕ)
     end
     convF
 end
@@ -134,7 +139,8 @@ function compute_LSF_matrix(synth_wls, obs_wls, R; window_size=4, verbose=true)
     LSF = spzeros((length(synth_wls), length(obs_wls)))
     for i in eachindex(obs_wls)
         λ0 = obs_wls[i]
-        line_spread_function_core!(view(LSF, :, i), 1.0, synth_wls, λ0, R, window_size)
+        lb, ub, normalized_ϕ = _lsf_bounds_and_kernel(synth_wls, λ0, R, window_size)
+        LSF[lb:ub, i] .+= normalized_ϕ
     end
     LSF'
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,7 @@ function merge_bounds(bounds, merge_distance=0.0)
     new_bounds = [bounds[1]]
     indices = [[bound_indices[1]]]
     for i in 2:length(bounds)
-        # if these bounds are within merge_distance of the previous, extend the previous, 
+        # if these bounds are within merge_distance of the previous, extend the previous,
         # otherwise add them to the list
         if bounds[i][1] <= new_bounds[end][2] + merge_distance
             new_bounds[end] = (new_bounds[end][1], max(bounds[i][2], new_bounds[end][2]))
@@ -49,7 +49,7 @@ function line_spread_function_core!(out, factor, synth_wls::Wavelengths, λ0, R:
 end
 # handle case where R is a function of wavelength
 function line_spread_function_core!(out, factor, synth_wls::Wavelengths, λ0, R, window_size)
-    # λ0 should have been converted to cm by the caller, but R is a functino of λ in Å
+    # λ0 should have been converted to cm by the caller, but R is a function of λ in Å
     line_spread_function_core!(out, factor, synth_wls, λ0, R(λ0 * 1e8), window_size)
 end
 
@@ -179,7 +179,7 @@ function _apply_rotation_core(flux, wls::StepRangeLen, vsini, ε=0.6)
     # precompute constants
     c1 = 2(1 - ε)
     c2 = π * ε / 2
-    # c3 is the denomicator.  the factor of v_L in Gray becomes Δλrot (because we are working in 
+    # c3 is the denomicator.  the factor of v_L in Gray becomes Δλrot (because we are working in
     # wavelenths) and moves inside the loop
     c3 = π * (1 - ε / 3)
 
@@ -198,7 +198,7 @@ function _apply_rotation_core(flux, wls::StepRangeLen, vsini, ε=0.6)
     newF
 end
 
-# the indefinite integral of the rotation kernel 
+# the indefinite integral of the rotation kernel
 function _rotation_kernel_integral_kernel(c1, c2, c3, detuning, Δλrot)
     if abs(detuning) == Δλrot
         return sign(detuning) * 0.5 # make it nan-safe for ForwardDiff

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -73,7 +73,7 @@
 
         # make sure the default window_size values are OK
         @test assert_allclose(convF, convF_mat5; atol=1e-4)
-        @test assert_allclose(convF_5sigma, convF_mat5; atol=1e-4)
+        @test assert_allclose(convF_5sigma, convF_mat5; rtol=1e-11)
         @test assert_allclose(convF_mat, convF_mat5; atol=1e-4)
 
         # but also check that they are definitely doing something
@@ -91,7 +91,7 @@
             c1 = 2(1 - ε)
             c2 = π * ε / 2
 
-            # step(wls) makes things normalized on the grid, and the factor of v_L in Gray becomes Δλrot 
+            # step(wls) makes things normalized on the grid, and the factor of v_L in Gray becomes Δλrot
             # (because we are working in wavelenths) and moves inside the loop
             denominator = π * (1 - ε / 3) / step(wls)
 


### PR DESCRIPTION
This refactors the LSF code to make ad-hoc LSF application (`Korg.apply_LSF`) and LSF matrices more consistently normalized. The behavior of `Korg.apply_LSF` now corresponds to multiplication by an LSF matrix which is column normalized rather than row-normalized (the previous behavior).  The upshot of this is that it removes the "edge effects".