### PR TITLE
correct C2 equilibrium constant with adjustment to BC table

### DIFF
--- a/src/species.jl
+++ b/src/species.jl
@@ -87,6 +87,9 @@ struct Formula
     end
 end
 
+# make it broadcast like a scalar
+Base.broadcastable(f::Formula) = Ref(f)
+
 """
     get_atoms(x)
 
@@ -245,6 +248,9 @@ function Species(code::AbstractString)
     Species(formula, charge)
 end
 Species(code::AbstractFloat) = Species(string(code))
+
+# make it broadcast like a scalar
+Base.broadcastable(s::Species) = Ref(s)
 
 #used to contruct Species at compile time and avoid parsing in hot loops
 macro species_str(s)

--- a/test/qfactors.jl
+++ b/test/qfactors.jl
@@ -34,7 +34,7 @@
     msk[1:100] .= false
 
     Q = Korg.Qfactor(synth_flux, synth_wls, apowls, LSF_model; obs_mask=msk)
-    @test Q≈810.9267657701387 rtol=1e-4
+    @test Q≈810.4642695969038 rtol=1e-4
     SNR = flux ./ obs_err
     RMS_SNR = sqrt(mean(SNR[msk] .^ 2))
     Q_prec = Korg.RV_prec_from_Q(Q, RMS_SNR, count(msk))


### PR DESCRIPTION
This corrects the C2 equilibrium constant to reflect the dissociation energy in [Visser + 2019](https://www.tandfonline.com/doi/full/10.1080/00268976.2018.1564849), which was recommended by [Aquilina+ 2024](https://ui.adsabs.harvard.edu/abs/2024MNRAS.531.4538A/).

Here's what the strongest C2 band in the visible looks like (at Teff=5000, logg=4.5, the new defaults for `synth`).
![image](https://github.com/user-attachments/assets/1c72e88c-5ead-4f99-a17c-c11f890a0967)

closes #312 