### PR TITLE
Threading

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -30,6 +30,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Set Julia threads
+        run: echo "JULIA_NUM_THREADS=4" >> $GITHUB_ENV
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/TestNightly.yml
+++ b/.github/workflows/TestNightly.yml
@@ -30,4 +30,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Set Julia threads
+        run: echo "JULIA_NUM_THREADS=4" >> $GITHUB_ENV
       - uses: julia-actions/julia-runtest@v1

--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -1,6 +1,16 @@
 ### What's the difference between `Korg.species` and `Korg.Species`?
-The short answer is that they do the same thing, but the lower-case version can only be applied to string literals.
-Both of these are ways to constructing objects of type [`Korg.Species`](@ref), which is used to represent atom and molecules with specific charges, e.g. C II or neutral FeH.  
+Short answer: you can always use `Korg.Species` like so: `Korg.Species("C II").
+Longer answer: they do the same thing, but the lower-case version can only be applied to string literals.
+Both of these are ways to constructing objects of type [`Korg.Species`](@ref), which is used to represent atom and molecules with specific charges, e.g. C II or neutral FeH.
 `Korg.Species` is the constructor, which acts like a normal function.  `Korg.species` is a [non-standard string literal](https://docs.julialang.org/en/v1/manual/metaprogramming/#meta-non-standard-string-literals), which is used without parentheses, like this: `Korg.species"Mg I"`.
 It can only be applied to string literals (things that you actually type out between quotes, not variables containing strings.)
 The string macro does the work of constructing the species object at compile time, which can make code much faster in specific circumstances.
+
+### Are Korg spectra bitwise reproducible?
+Korg spectra should be bitwise reproducible under these conditions:
+- Using a single thread (Julia's default configuration)
+- Running on the same machine
+- Using identical Korg and dependency versions
+- Providing identical input parameters
+
+When running with multiple threads, small numerical differences may occur due to floating-point operations being performed in different orders.

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -1,5 +1,6 @@
 using SpecialFunctions: gamma
 using ProgressMeter: @showprogress
+using Base.Iterators: partition
 
 """
     line_absorption!(α, linelist, λs, temp, nₑ, n_densities, partition_fns, ξ
@@ -30,10 +31,6 @@ function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densiti
         return zeros(length(λs))
     end
 
-    #lb and ub are the indices to the upper and lower wavelengths in the "window", i.e. the shortest
-    #and longest wavelengths which feel the effect of each line 
-    lb = 1
-    ub = 1
     β = @. 1 / (kboltz_eV * temps)
 
     # precompute number density / partition function for each species in the linelist
@@ -44,58 +41,85 @@ function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densiti
         @error "Atomic hydrogen should not be in the linelist. Korg has built-in hydrogen lines."
     end
 
-    # preallocate some arrays for the core loop. 
-    # Each element of the arrays corresponds to an atmospheric layer, same at the "temps" array and 
-    # the values in "number_densities"
-    Γ = Vector{eltype(α)}(undef, size(temps))
-    γ = Vector{eltype(α)}(undef, size(temps))
-    σ = Vector{eltype(α)}(undef, size(temps))
-    amplitude = Vector{eltype(α)}(undef, size(temps))
-    levels_factor = Vector{eltype(α)}(undef, size(temps))
-    ρ_crit = Vector{eltype(α)}(undef, size(temps))
-    inverse_densities = Vector{eltype(α)}(undef, size(temps))
-    @showprogress desc="calculating line opacities" enabled=verbose for line in linelist
-        m = get_mass(line.species)
+    # TODO
+    tasks_per_thread = 2 # customize this as needed. More tasks have more overhead, but better
+    # load balancing
+    chunk_size = max(1, length(linelist) ÷ (tasks_per_thread * Threads.nthreads()))
+    linelist_chunks = partition(linelist, chunk_size)
 
-        # doppler-broadening width, σ (NOT √[2]σ)
-        σ .= doppler_width.(line.wl, temps, m, ξ)
+    α_lock = ReentrantLock()
 
-        # sum up the damping parameters.  These are FWHM (γ is usually the Lorentz HWHM) values in 
-        # angular, not cyclical frequency (ω, not ν).
-        Γ .= line.gamma_rad
-        if !ismolecule(line.species)
-            @. Γ += nₑ * scaled_stark.(line.gamma_stark, temps)
-            Γ .+= n_densities[species"H_I"] .* scaled_vdW.(Ref(line.vdW), m, temps)
+    tasks = map(linelist_chunks) do linelist_chunk
+        # Each chunk of your data gets its own spawned task that does its own local, sequential work
+        # and then returns the result
+        Threads.@spawn begin
+            #lb and ub are the indices to the upper and lower wavelengths in the "window", i.e. the shortest
+            #and longest wavelengths which feel the effect of each line
+            # TODO does it make sense to preallocate these????
+            lb = 1
+            ub = 1
+
+            # preallocate some arrays for the core loop.
+            # Each element of the arrays corresponds to an atmospheric layer, same at the "temps" array and
+            # the values in "number_densities"
+            Γ = Vector{eltype(α)}(undef, size(temps))
+            γ = Vector{eltype(α)}(undef, size(temps))
+            σ = Vector{eltype(α)}(undef, size(temps))
+            amplitude = Vector{eltype(α)}(undef, size(temps))
+            levels_factor = Vector{eltype(α)}(undef, size(temps))
+            ρ_crit = Vector{eltype(α)}(undef, size(temps))
+            inverse_densities = Vector{eltype(α)}(undef, size(temps))
+
+            for line in linelist
+                m = get_mass(line.species)
+
+                # doppler-broadening width, σ (NOT √[2]σ)
+                σ .= doppler_width.(line.wl, temps, m, ξ)
+
+                # sum up the damping parameters.  These are FWHM (γ is usually the Lorentz HWHM) values in
+                # angular, not cyclical frequency (ω, not ν).
+                Γ .= line.gamma_rad
+                if !ismolecule(line.species)
+                    @. Γ += nₑ * scaled_stark.(line.gamma_stark, temps)
+                    Γ .+= n_densities[species"H_I"] .* scaled_vdW.(Ref(line.vdW), m, temps)
+                end
+                # calculate the lorentz broadening parameter in wavelength. Doing this involves an
+                # implicit aproximation that λ(ν) is linear over the line window.
+                # the factor of λ²/c is |dλ/dν|, the factor of 1/2π is for angular vs cyclical freqency,
+                # and the last factor of 1/2 is for FWHM vs HWHM
+                @. γ = Γ * line.wl^2 / (c_cgs * 4π)
+
+                E_upper = line.E_lower + c_cgs * hplanck_eV / line.wl
+                @. levels_factor = exp(-β * line.E_lower) - exp(-β * E_upper)
+
+                #total wl-integrated absorption coefficient
+                @. amplitude = 10.0^line.log_gf * sigma_line(line.wl) * levels_factor *
+                               n_div_Z[line.species]
+
+                ρ_crit .= (line.wl .|> α_cntm) .* cutoff_threshold ./ amplitude
+                inverse_densities .= inverse_gaussian_density.(ρ_crit, σ)
+                doppler_line_window = maximum(inverse_densities)
+                inverse_densities .= inverse_lorentz_density.(ρ_crit, γ)
+                lorentz_line_window = maximum(inverse_densities)
+                window_size = sqrt(lorentz_line_window^2 + doppler_line_window^2)
+                # at present, this line is allocating. Would be good to fix that.
+                lb = searchsortedfirst(λs, line.wl - window_size)
+                ub = searchsortedlast(λs, line.wl + window_size)
+                # not necessary, but is faster as of 8f979cc2c28f45cd7230d9ee31fbfb5a5164eb1d
+                if lb > ub
+                    continue
+                end
+
+                @lock α_lock begin
+                    view(α, :, lb:ub) .+= line_profile.(line.wl, σ, γ, amplitude, view(λs, lb:ub)')
+                end
+            end
         end
-        # calculate the lorentz broadening parameter in wavelength. Doing this involves an 
-        # implicit aproximation that λ(ν) is linear over the line window.
-        # the factor of λ²/c is |dλ/dν|, the factor of 1/2π is for angular vs cyclical freqency,
-        # and the last factor of 1/2 is for FWHM vs HWHM
-        @. γ = Γ * line.wl^2 / (c_cgs * 4π)
-
-        E_upper = line.E_lower + c_cgs * hplanck_eV / line.wl
-        @. levels_factor = exp(-β * line.E_lower) - exp(-β * E_upper)
-
-        #total wl-integrated absorption coefficient
-        @. amplitude = 10.0^line.log_gf * sigma_line(line.wl) * levels_factor *
-                       n_div_Z[line.species]
-
-        ρ_crit .= (line.wl .|> α_cntm) .* cutoff_threshold ./ amplitude
-        inverse_densities .= inverse_gaussian_density.(ρ_crit, σ)
-        doppler_line_window = maximum(inverse_densities)
-        inverse_densities .= inverse_lorentz_density.(ρ_crit, γ)
-        lorentz_line_window = maximum(inverse_densities)
-        window_size = sqrt(lorentz_line_window^2 + doppler_line_window^2)
-        # at present, this line is allocating. Would be good to fix that.
-        lb = searchsortedfirst(λs, line.wl - window_size)
-        ub = searchsortedlast(λs, line.wl + window_size)
-        # not necessary, but is faster as of 8f979cc2c28f45cd7230d9ee31fbfb5a5164eb1d
-        if lb > ub
-            continue
-        end
-
-        view(α, :, lb:ub) .+= line_profile.(line.wl, σ, γ, amplitude, view(λs, lb:ub)')
     end
+
+    # TODO is this the best way?
+    fetch.(tasks)
+    return nothing
 end
 
 """

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -25,7 +25,7 @@ other arguments:
   - `cuttoff_threshold` (default: 3e-4): see `α_cntm`
   - `tasks_per_thread` (default: 1): the number of tasks to run per Julia thread. This function
     is multithreaded over the lines in `linelist`.
-  - `verbose` (default: false): if true, show a progress bar.
+  - `verbose` (deprecated): no longer used.
 """
 function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densities, partition_fns, ξ,
                           α_cntm; cutoff_threshold=3e-4, verbose=false, tasks_per_thread=1)

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -43,7 +43,8 @@ function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densiti
         @error "Atomic hydrogen should not be in the linelist. Korg has built-in hydrogen lines."
     end
 
-    chunk_size = max(1, length(linelist) ÷ (tasks_per_thread * Threads.nthreads()))
+    n_chunks = tasks_per_thread * Threads.nthreads()
+    chunk_size = max(1, length(linelist) ÷ n_chunks + (length(linelist) % n_chunks > 0))
     linelist_chunks = partition(linelist, chunk_size)
     tasks = map(linelist_chunks) do linelist_chunk
         # Each chunk of your data gets its own spawned task that does its own local, sequential work

--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -23,10 +23,12 @@ other arguments:
 # Keyword Arguments
 
   - `cuttoff_threshold` (default: 3e-4): see `α_cntm`
+  - `tasks_per_thread` (default: 1): the number of tasks to run per Julia thread. This function
+    is multithreaded over the lines in `linelist`.
   - `verbose` (default: false): if true, show a progress bar.
 """
 function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densities, partition_fns, ξ,
-                          α_cntm; cutoff_threshold=3e-4, verbose=false)
+                          α_cntm; cutoff_threshold=3e-4, verbose=false, tasks_per_thread=1)
     if length(linelist) == 0
         return zeros(length(λs))
     end
@@ -41,14 +43,8 @@ function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densiti
         @error "Atomic hydrogen should not be in the linelist. Korg has built-in hydrogen lines."
     end
 
-    # TODO
-    tasks_per_thread = 1 # customize this as needed. More tasks have more overhead, but better
-    # load balancing
     chunk_size = max(1, length(linelist) ÷ (tasks_per_thread * Threads.nthreads()))
     linelist_chunks = partition(linelist, chunk_size)
-    #TODO
-    #linelist_chunks = [linelist]
-
     tasks = map(linelist_chunks) do linelist_chunk
         # Each chunk of your data gets its own spawned task that does its own local, sequential work
         # and then returns the result

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Korg, Test, Logging, HDF5, ForwardDiff, FiniteDiff, Aqua
 
+println("running test suite with  ", Threads.nthreads(), " threads.")
+
 @testset "Korg tests" verbose=true showtiming=true begin
 
     # tools for testing: assert_allclose and assert_allclose_grid


### PR DESCRIPTION
This PR introduces thread parallelism to speed up parts of the calculation.  In the past, my philosophy was that Korg should be entirely serial, because you can always parallelize over stars/spectra.  However, it's still nice to have a single synthesis go faster on your laptop, and multithreading makes it easier to saturate the cores on a node without bumping into the memory ceiling.

[See here for how to set the number of julia threads](https://docs.julialang.org/en/v1/manual/multi-threading/) (it's `-t` or `$JULIA_NUM_THEADS`).  If you do nothing, you will continue to get the serial behavior which should have the same performance as before.