### PR TITLE
Benchmark suite

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,9 +1,8 @@
 name: Benchmark a pull request
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  workflow_dispatch:
+  pull_request:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on:
   pull_request:
     branches: [ main ]   # change if your default branch differs
-  workflow_dispatch:     # allows manual triggering
+  workflow_dispatch:     # allows manual triggering for PRs from forks
 
 permissions:
   pull-requests: write    # needed to post comments

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,0 +1,65 @@
+name: Benchmark a pull request
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+    generate_table:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v2
+              with:
+                version: "1"
+            - uses: julia-actions/cache@v2
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v3
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
+
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,64 +1,23 @@
-name: Benchmark a pull request
+name: Benchmark
 
 on:
-  workflow_dispatch:
   pull_request:
+    branches: [ main ]   # change if your default branch differs
+  workflow_dispatch:     # allows manual triggering
 
 permissions:
-  pull-requests: write
+  pull-requests: write    # needed to post comments
 
 jobs:
-    generate_table:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: julia-actions/setup-julia@v2
-              with:
-                version: "1"
-            - uses: julia-actions/cache@v2
-            - name: Extract Package Name from Project.toml
-              id: extract-package-name
-              run: |
-                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-                echo "::set-output name=package_name::$PACKAGE_NAME"
-            - name: Build AirspeedVelocity
-              env:
-                JULIA_NUM_THREADS: 2
-              run: |
-                # Lightweight build step, as sometimes the runner runs out of memory:
-                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
-                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
-            - name: Add ~/.julia/bin to PATH
-              run: |
-                echo "$HOME/.julia/bin" >> $GITHUB_PATH
-            - name: Run benchmarks
-              run: |
-                echo $PATH
-                ls -l ~/.julia/bin
-                mkdir results
-                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/
-            - name: Create markdown table from benchmarks
-              run: |
-                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
-                echo '### Benchmark Results' > body.md
-                echo '' >> body.md
-                echo '' >> body.md
-                cat table.md >> body.md
-                echo '' >> body.md
-                echo '' >> body.md
-
-            - name: Find Comment
-              uses: peter-evans/find-comment@v3
-              id: fcbenchmark
-              with:
-                issue-number: ${{ github.event.pull_request.number }}
-                comment-author: 'github-actions[bot]'
-                body-includes: Benchmark Results
-
-            - name: Comment on PR
-              uses: peter-evans/create-or-update-comment@v4
-              with:
-                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
-                issue-number: ${{ github.event.pull_request.number }}
-                body-path: body.md
-                edit-mode: replace
+  bench:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia-version: ["1"] # could also add 1.10 (LTS), but not needed
+    steps:
+      - uses: actions/checkout@v4 # don't need to specify because of the on: pull_request
+      - name: Benchmark PR with AirspeedVelocity
+        uses: MilesCranmer/AirspeedVelocity.jl@action-v1.1.0
+        with:
+          julia-version: ${{ matrix.julia-version }}
+          job-summary: 'false'

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         julia-version: ["1"] # could also add 1.10 (LTS), but not needed
     steps:
-      - uses: actions/checkout@v4 # don't need to specify because of the on: pull_request
       - name: Benchmark PR with AirspeedVelocity
         uses: MilesCranmer/AirspeedVelocity.jl@action-v1.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /Manifest.toml
 test/Manifest.toml
 docs/Manifest.toml
+benchmark/Manifest.toml
 sanity_checks/Manifest.toml
 *.jl~
 misc/Tutorial\ notebooks/Project.toml

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ misc/d.pdf
 misc/*.png
 docs/build/
 *.DS_Store
+results_*.json
+results_*.json.tmp

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,39 @@
+using BenchmarkTools, Korg
+
+const SUITE = BenchmarkGroup()
+
+# the PACKAGE_VERSION constant can be used to run tweaked benchmarks for different versions of Korg
+
+# Stellar parameters for benchmarks
+const BENCHMARK_PARAMS = [
+    ("sun", (Teff=5777, logg=4.44, m_H=0.0)),
+    ("M dwarf", (Teff=3500, logg=4.6, m_H=0.0))
+]
+
+const WAVELENGTH_RANGES_AND_LINELISTS = [
+    ("one wavelength", (5000, 5000), []),
+    ("4000 Å - 8000 Å VALD solar", (4000, 8000), Korg.get_VALD_solar_linelist()),
+    ("APOGEE DR17 w/o water", (15000, 17000), Korg.get_APOGEE_DR17_linelist(; include_water=false)),
+    ("500 Å of APOGEE w/ water", (15500, 16000), Korg.get_APOGEE_DR17_linelist())
+]
+
+SUITE["synthesis"] = BenchmarkGroup()
+for (i, (param_name, params)) in enumerate(BENCHMARK_PARAMS)
+    SUITE["synthesis"][param_name] = BenchmarkGroup()
+
+    # Test different wavelength ranges
+    for (j, (range_name, wl_range, linelist)) in enumerate(WAVELENGTH_RANGES_AND_LINELISTS)
+        try
+            SUITE["synthesis"][param_name][range_name] = @benchmarkable synth(Teff=$(params.Teff),
+                                                                              logg=$(params.logg),
+                                                                              m_H=$(params.m_H),
+                                                                              linelist=$linelist,
+                                                                              wavelengths=$wl_range) setup=(GC.gc()) seconds=30
+        catch e
+            @warn "Could not run benchmark for $param_name/$range_name: $e"
+        end
+    end
+end
+
+results = run(SUITE)
+println(results)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -14,7 +14,7 @@ const WAVELENGTH_RANGES_AND_LINELISTS = [
     ("one wavelength", (5000, 5000), []),
     ("4000 Å - 8000 Å VALD solar", (4000, 8000), Korg.get_VALD_solar_linelist()),
     ("APOGEE DR17 w/o water", (15000, 17000), Korg.get_APOGEE_DR17_linelist(; include_water=false)),
-    ("500 Å of APOGEE w/ water", (15500, 16000), Korg.get_APOGEE_DR17_linelist())
+    ("100 Å of APOGEE w/ water", (15500, 15600), Korg.get_APOGEE_DR17_linelist())
 ]
 
 SUITE["synthesis"] = BenchmarkGroup()


### PR DESCRIPTION
This adds a rudimentary benchmark suite, `benchmark/benchmarks.jl`, and a github action to run it on PRs.

The benchmark suite itself is written with BenchmarkTools, which is well established.  I'm using AirspeedVelocity.jl, which provides nice CLI tooling and makes tables/plots for the github action.