### PR TITLE
Reduce the number of allocs when calculating line window indices

### DIFF
--- a/src/line_absorption.jl
+++ b/src/line_absorption.jl
@@ -95,7 +95,6 @@ function line_absorption!(α, linelist, λs::Wavelengths, temps, nₑ, n_densiti
                 inverse_densities .= inverse_lorentz_density.(ρ_crit, γ)
                 lorentz_line_window = maximum(inverse_densities)
                 window_size = sqrt(lorentz_line_window^2 + doppler_line_window^2)
-                # at present, this line is allocating. Would be good to fix that.
                 lb = searchsortedfirst(λs, line.wl - window_size)
                 ub = searchsortedlast(λs, line.wl + window_size)
                 # not necessary, but is faster as of 8f979cc2c28f45cd7230d9ee31fbfb5a5164eb1d

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -9,6 +9,9 @@ a vector of upper and lower bounds. For example,
     Korg.Wavelengths(5000, 5500, 0.01) # explicitly specify the spacing (0.01 Å is the default)
     Korg.Wavelengths([(5000, 5500), (6000, 6500)])
 
+Wavelengths can be specified in either Å or cm. Values >= 1 are assumed to be in Å and values < 1
+are assumed to be in cm.
+
 # Keyword Arguments
 
   - `air_wavelengths` (default: `false`): Whether or not the input wavelengths are air wavelengths to

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -6,6 +6,7 @@ which to compute a spectrum.  The wavelengths can be specified with an upper and
 a vector of upper and lower bounds. For example,
 
     Korg.Wavelengths(5000, 5500)
+    Korg.Wavelengths(5000, 5500, 0.01) # explicitly specify the spacing (0.01 Å is the default)
     Korg.Wavelengths([(5000, 5500), (6000, 6500)])
 
 # Keyword Arguments

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -60,7 +60,7 @@ struct Wavelengths{F} <: AbstractArray{F,1}
         new{eltype(all_wls)}(wl_ranges, all_wls, all_freqs)
     end
 end
-function Wavelengths(wls::Wavelengths; air_wavelengths=false,)
+function Wavelengths(wls::Wavelengths; air_wavelengths=false, kwargs...)
     if air_wavelengths
         Wavelengths(wls.wl_ranges; air_wavelengths=true, kwargs...)
     else
@@ -68,7 +68,9 @@ function Wavelengths(wls::Wavelengths; air_wavelengths=false,)
     end
 end
 Wavelengths(wls::R; kwargs...) where R<:AbstractRange = Wavelengths([wls]; kwargs...)
-function Wavelengths(wls::AbstractVector{<:Real}; tolerance=1e-6, kwargs...)
+# this handles the vector of wl values case. The eltype is unspecified (Any) so that
+# empty vectors get dispatched to this method.
+function Wavelengths(wls::AbstractVector; tolerance=1e-6, kwargs...)
     if length(wls) == 0
         throw(ArgumentError("wavelengths must be non-empty"))
     elseif length(wls) == 1

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -161,37 +161,25 @@ end
 
 # index of the first element greater than or equal to λ
 function Base.Sort.searchsortedfirst(wls::Wavelengths, λ)
-    if λ >= 1 # convert Å to cm
-        λ *= 1e-8
+    λ = λ >= 1 ? λ * 1e-8 : λ  # Convert Å to cm if needed
+    ind = 0
+    for range in wls.wl_ranges
+        if λ <= last(range)
+            return ind + searchsortedfirst(range, λ)
+        end
+        ind += length(range)
     end
-    range_ind = 1
-    while (range_ind <= length(wls.wl_ranges)) && (λ > last(wls.wl_ranges[range_ind]))
-        range_ind += 1
-    end
-    if range_ind == length(wls.wl_ranges) + 1
-        return length(wls) + 1
-    end
-    ind = searchsortedfirst(wls.wl_ranges[range_ind], λ)
-    for ri in 1:range_ind-1
-        ind += length(wls.wl_ranges[ri])
-    end
-    ind
+    length(wls) + 1
 end
 # index of the last element less than or equal to λ
 function Base.Sort.searchsortedlast(wls::Wavelengths, λ)
-    if λ >= 1 # convert Å to cm
-        λ *= 1e-8
+    λ = λ >= 1 ? λ * 1e-8 : λ  # Convert Å to cm if needed
+    ind = 0
+    for range in wls.wl_ranges
+        if λ <= last(range)
+            return ind + searchsortedlast(range, λ)
+        end
+        ind += length(range)
     end
-    range_ind = 0
-    while (range_ind < length(wls.wl_ranges)) && (first(wls.wl_ranges[range_ind+1]) <= λ)
-        range_ind += 1
-    end
-    if range_ind == 0
-        return 0
-    end
-    ind = searchsortedlast(wls.wl_ranges[range_ind], λ)
-    for ri in 1:range_ind-1
-        ind += length(wls.wl_ranges[ri])
-    end
-    ind
+    length(wls)
 end

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -1,6 +1,5 @@
 @testset "Wavelengths" begin
     @testset "constructor" begin
-
         @test_throws "wavelengths must be non-empty" Korg.Wavelengths([])
 
         wls = Korg.Wavelengths(15000, 15500)
@@ -44,13 +43,13 @@
     end
 
     @testset "searchsortedfirst/last" begin
-
         # give the target wavelengths in both Å and cm
         @testset for conversion_factor in [1, 1e-8]
             wls = Korg.Wavelengths(0.5 .+ (2:10))
             @test searchsortedfirst(wls, 4.0 * conversion_factor) == 3
             @test searchsortedfirst(wls, 1.5 * conversion_factor) == 1
-            @test searchsortedfirst(wls, 3.0 * conversion_factor) == 2
+            @test searchsortedfirst(wls, 3 * conversion_factor) == 2
+
             @test searchsortedlast(wls, 8 * conversion_factor) == 6
             @test searchsortedlast(wls, 4 * conversion_factor) == 2
             @test searchsortedlast(wls, 11 * conversion_factor) == 9
@@ -60,14 +59,14 @@
             @test searchsortedlast(wls, 5.6 * conversion_factor) == 5
 
             wls = Korg.Wavelengths([3:5, 11:0.5:12.5, 16:20])
-            @test searchsortedfirst(wls, 2) == 1
-            @test searchsortedfirst(wls, 11.9) == 6
-            @test searchsortedfirst(wls, 45) == 13
-            @test searchsortedlast(wls, 2) == 0
-            @test searchsortedlast(wls, 4) == 2
-            @test searchsortedlast(wls, 11) == 4
-            @test searchsortedlast(wls, 13.1) == 7
-            @test searchsortedlast(wls, 55) == 12
+            @test searchsortedfirst(wls, 2 * conversion_factor) == 1
+            @test searchsortedfirst(wls, 11.9 * conversion_factor) == 6
+            @test searchsortedfirst(wls, 45 * conversion_factor) == 13
+            @test searchsortedlast(wls, 2 * conversion_factor) == 0
+            @test searchsortedlast(wls, 4 * conversion_factor) == 2
+            @test searchsortedlast(wls, 11 * conversion_factor) == 4
+            @test searchsortedlast(wls, 13.1 * conversion_factor) == 7
+            @test searchsortedlast(wls, 55 * conversion_factor) == 12
         end
     end
 end

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -2,6 +2,17 @@
     @testset "constructor" begin
         @test_throws "wavelengths must be non-empty" Korg.Wavelengths([])
 
+        # Non-sorted and overlapping ranges should throw
+        @test_throws ArgumentError Korg.Wavelengths([5000:1.0:5010, 5005:1.0:5020])
+        @test_throws ArgumentError Korg.Wavelengths([5020:1.0:5030, 5000:1.0:5010])
+
+        # Single-element vector input
+        wls_single = Korg.Wavelengths([12345.6])
+        wls_single_range = Korg.Wavelengths(12345.6, 12345.6)
+        @test wls_single == wls_single_range
+        @test length(wls_single) == 1
+        @test wls_single[1] ≈ 12345.6 * 1e-8
+
         wls = Korg.Wavelengths(15000, 15500)
         @test wls == Korg.Wavelengths((15000, 15500))
         @test wls == Korg.Wavelengths([(15000, 15500)])
@@ -68,5 +79,23 @@
             @test searchsortedlast(wls, 13.1 * conversion_factor) == 7
             @test searchsortedlast(wls, 55 * conversion_factor) == 12
         end
+    end
+
+    @testset "array interface" begin
+        wls = Korg.Wavelengths(7000, 7002, 1.0)
+        @test length(wls) == 3
+        @test size(wls) == (3,)
+        @test wls[1] ≈ 7000 * 1e-8
+        @test wls[2] ≈ 7001 * 1e-8
+        @test wls[3] ≈ 7002 * 1e-8
+    end
+
+    @testset "eachwindow and eachfreq" begin
+        wls = Korg.Wavelengths([8000:1.0:8002, 8100:2.0:8104])
+        windows = collect(Korg.eachwindow(wls))
+        @test windows == [(8000e-8, 8002e-8), (8100e-8, 8104e-8)]
+        freqs = Korg.eachfreq(wls)
+        @test issorted(freqs)
+        @test length(freqs) == length(wls)
     end
 end

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -1,5 +1,8 @@
 @testset "Wavelengths" begin
     @testset "constructor" begin
+
+        @test_throws "wavelengths must be non-empty" Korg.Wavelengths([])
+
         wls = Korg.Wavelengths(15000, 15500)
         @test wls == Korg.Wavelengths((15000, 15500))
         @test wls == Korg.Wavelengths([(15000, 15500)])


### PR DESCRIPTION
- make sure all the members of `Korg.Wavelengths` have concrete types
- don't construct arrays in the implementation of `searchsortedfirst`/`searchsortedlast` for `Wavelengths`
- correct a method precedence problem that was causing the specialized error for constructing an empty `Wavelengths` from every being raised.