### PR TITLE
pass the wavelengths object, not the concat'ed wavelengths

### DIFF
--- a/src/synth.jl
+++ b/src/synth.jl
@@ -51,6 +51,8 @@ function synth(;
     A_X = format_A_X(m_H, alpha_H, abundances; format_A_X_kwargs...)
     atm = interpolate_marcs(Teff, logg, A_X)
 
+    wavelengths = Korg.Wavelengths(wavelengths)
+
     # synthesize kwargs currently must be symbols, which is annoying
     spectrum = synthesize(atm, linelist, A_X, wavelengths; vmic, synthesize_kwargs...)
     flux = if rectify
@@ -62,7 +64,7 @@ function synth(;
         flux = apply_LSF(flux, spectrum.wavelengths, R)
     end
     if vsini > 0
-        flux = apply_rotation(flux, spectrum.wavelengths, vsini)
+        flux = apply_rotation(flux, wavelengths, vsini)
     end
 
     spectrum.wavelengths, flux, spectrum.cntm

--- a/test/synth.jl
+++ b/test/synth.jl
@@ -30,7 +30,7 @@
         wls, flux_rot, _ = synth(; wavelengths=wl_spec, vsini=10)
         wls_raw, flux_raw, _ = synth(; wavelengths=wl_spec, vsini=0)
         @assert wls == wls_raw
-        flux_manual_rot = Korg.apply_rotation(flux_raw, wls_raw, 10)
+        flux_manual_rot = Korg.apply_rotation(flux_raw, wl_spec, 10)
         @test flux_rot ≈ flux_manual_rot
     end
 

--- a/test/synth.jl
+++ b/test/synth.jl
@@ -26,8 +26,9 @@
     end
 
     @testset "rotation" begin
-        wls, flux_rot, _ = synth(; wavelengths=(5000, 5001), vsini=10)
-        wls_raw, flux_raw, _ = synth(; wavelengths=(5000, 5001), vsini=0)
+        wl_spec = [(5000, 5001), (5002, 5003)]
+        wls, flux_rot, _ = synth(; wavelengths=wl_spec, vsini=10)
+        wls_raw, flux_raw, _ = synth(; wavelengths=wl_spec, vsini=0)
         @assert wls == wls_raw
         flux_manual_rot = Korg.apply_rotation(flux_raw, wls_raw, 10)
         @test flux_rot ≈ flux_manual_rot


### PR DESCRIPTION
Fix bug where `synth` would error when using noncontiguous wavelengths and nonzero vsini at the same time.  