### PR TITLE
Add .git-blame-ignore-revs and ignore the commit where I did a global reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# reformat with JuliaFormatter
+832d31c6ae57933ad08879b6550aa823dd6cba7e


### PR DESCRIPTION
GitHub will use this automatically (I think?), and you can configure your local repo to use it with 
```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
which will edit your `.git/config` file.