### PR TITLE
output flux with Å for wavelengths unit, not cm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ wls, flux, continuum = synth(
 figure(figsize=(12, 4))
 plot(wls, flux, "k-")
 xlabel(L"$\lambda$ [Å]")
-ylabel(L"$F_\lambda/R_\mathrm{star}^2$ [erg s$^{-1}$ cm$^{-5}$]");
+ylabel(L"$F_\lambda/R_\mathrm{star}^2$ [erg s$^{-1}$ cm$^{-4} \AA^{-1}$]");
 ```
 See the [documentation for `synth`](https://ajwheeler.github.io/Korg.jl/stable/API/#Korg.synth), or [the documentation for `synthesize`](https://ajwheeler.github.io/Korg.jl/stable/API/#Korg.synth) for advanced usage.
 

--- a/src/synth.jl
+++ b/src/synth.jl
@@ -4,7 +4,7 @@
 This function creates a synthetic spectrum. It's easier to use than [`synthesize`](@ref), but it
 gives you less control. Unlike [`synthesize`](@ref), it **returns a tuple of
 `(wavelengths, rectified_flux, cntm)`** (Wavelength in Å, rectified flux as a unitless number
-between 0 and 1, and continuum in erg/s/cm^5).  `Korg.synth` also provides shortcuts for some ways
+between 0 and 1, and continuum in erg/s/cm^4/Å).  `Korg.synth` also provides shortcuts for some ways
 you might want to post-process the spectrum (applying a LSF, rotation, etc).
 
 # Keyword arguments

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -9,8 +9,9 @@ The result of a synthesis. Returned by [`synthesize`](@ref).
 
 # Fields
 
-  - `flux`: the output spectrum
-  - `cntm`: the continuum at each wavelength
+  - `flux`: the output spectrum, in units of erg/s/cm^4/Å
+  - `cntm`: the continuum at each wavelength, in the same units as `flux`. This is the same as the
+    spectrum obtained with an empty linelist and with H lines turned off.
   - `intensity`: the intensity at each wavelength and mu value, and possibly each layer in the model
     atmosphere, depending on the radiative transfer scheme.
   - `alpha`: the linear absorption coefficient at each wavelength and atmospheric layer a Matrix of
@@ -274,9 +275,12 @@ function synthesize(atm::ModelAtmosphere, linelist, A_X::AbstractVector{<:Real},
                                                                               mu_values; α_ref=α5,
                                                                               I_scheme=I_scheme,
                                                                               τ_scheme=tau_scheme)
+    # convert from erg/s/cm^5 to erg/s/cm^4/Å.
+    flux .*= 1e-8
+    cntm .*= 1e-8
 
-    SynthesisResult(; flux=flux, cntm=cntm, intensity=intensity, alpha=α,
-                    mu_grid=collect(zip(μ_grid, μ_weights)), number_densities=number_densities,
+    SynthesisResult(; flux, cntm, intensity, alpha=α,
+                    mu_grid=collect(zip(μ_grid, μ_weights)), number_densities,
                     electron_number_density=nₑs, wavelengths=wls .* 1e8,
                     subspectra=subspectrum_indices(wls))
 end

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -32,7 +32,7 @@
             else
                 "spherical"
             end
-            @test assert_allclose_grid(sol.flux, flux,
+            @test assert_allclose_grid(sol.flux, flux * 1e-8,
                                        [("λ [$I_scheme $τ_scheme $atmtype]", sol.wavelengths, "Å")];
                                        rtol=0.05, print_rachet_info=false)
         end


### PR DESCRIPTION
fixes #364 

The is what most people expect, especially since the wavelengths input and output are in \AA.  It's also yields better float precision, though not in practice given how it's implemented at the moment.