### PR TITLE
De-footgun synth

### DIFF
--- a/src/synth.jl
+++ b/src/synth.jl
@@ -9,8 +9,8 @@ you might want to post-process the spectrum (applying a LSF, rotation, etc).
 
 # Keyword arguments
 
-  - `Teff`: effective temperature in K (default: 5000)
-  - `logg`: surface gravity in cgs units (default: 4.5)
+  - `Teff`: effective temperature in K (no default, must be provided)
+  - `logg`: surface gravity in cgs units (no default, must be provided)
   - `m_H`: metallicity, [metals/H], (default: 0.0) (See [`format_A_X`](@ref) for precisely
     how this is interpreted.)
   - `alpha_H`: alpha enhancement, [α/H], (default: `m_H`) (See [`format_A_X`](@ref) for precisely
@@ -35,8 +35,8 @@ you might want to post-process the spectrum (applying a LSF, rotation, etc).
   - `format_A_X_kwargs`: additional keyword arguments pass to [`format_A_X`](@ref).
 """
 function synth(;
-               Teff=5000,
-               logg=4.5,
+               Teff=nothing,
+               logg=nothing,
                m_H=0.0,
                alpha_H=m_H,
                linelist=get_VALD_solar_linelist(),
@@ -48,6 +48,9 @@ function synth(;
                synthesize_kwargs=Dict(),
                format_A_X_kwargs=Dict(),
                abundances...,)
+    if isnothing(Teff) || isnothing(logg)
+        throw(ArgumentError("Teff and logg must be passed to synth as keyword arguments"))
+    end
     A_X = format_A_X(m_H, alpha_H, abundances; format_A_X_kwargs...)
     atm = interpolate_marcs(Teff, logg, A_X)
 
@@ -60,9 +63,7 @@ function synth(;
     else
         spectrum.flux
     end
-    if isfinite(R)
-        flux = apply_LSF(flux, spectrum.wavelengths, R)
-    end
+    flux = apply_LSF(flux, spectrum.wavelengths, R)
     if vsini > 0
         flux = apply_rotation(flux, wavelengths, vsini)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,6 +86,9 @@ will get much better performance using [`compute_LSF_matrix`](@ref).
         otherwise desired) grid.
 """
 function apply_LSF(flux::AbstractVector{F}, wls, R; window_size=4) where F<:Real
+    if R == Inf
+        return copy(flux)
+    end
     wls = Wavelengths(wls)
     convF = zeros(F, length(flux))
     for i in eachindex(wls)

--- a/test/synth.jl
+++ b/test/synth.jl
@@ -1,10 +1,11 @@
 @testset "synth" begin
     default_linelist = Korg.get_VALD_solar_linelist()
     default_atm = interpolate_marcs(5000, 4.5, format_A_X())
+    default_ps = (; Teff=5000, logg=4.5)
 
     @testset "basic functionality" begin
         # Compare with direct Korg.synthesize call
-        wls, flux, cntm = synth(; wavelengths=(5000, 5001))
+        wls, flux, cntm = synth(; default_ps..., wavelengths=(5000, 5001))
         sol = synthesize(default_atm, default_linelist, format_A_X(), 5000, 5001)
         @test wls == sol.wavelengths
         @test flux ≈ sol.flux ./ sol.cntm
@@ -12,14 +13,14 @@
     end
 
     @testset "rectification" begin
-        wls1, flux_rect, cntm = synth(; wavelengths=(5000, 5001), rectify=true)
+        wls1, flux_rect, cntm = synth(; default_ps..., wavelengths=(5000, 5001), rectify=true)
         wls2, flux_raw, _ = synth(; wavelengths=(5000, 5001), rectify=false)
         @test flux_rect ≈ flux_raw ./ cntm
     end
 
     @testset "resolution" begin
-        wls, flux_lsf, _ = synth(; wavelengths=(5000, 5001), R=50_000)
-        wls_raw, flux_raw, _ = synth(; wavelengths=(5000, 5001), R=Inf)
+        wls, flux_lsf, _ = synth(; default_ps..., wavelengths=(5000, 5001), R=50_000)
+        wls_raw, flux_raw, _ = synth(; default_ps..., wavelengths=(5000, 5001), R=Inf)
         @assert wls == wls_raw
         flux_manual_lsf = Korg.apply_LSF(flux_raw, wls_raw, 50_000)
         @test flux_lsf ≈ flux_manual_lsf
@@ -27,8 +28,8 @@
 
     @testset "rotation" begin
         wl_spec = [(5000, 5001), (5002, 5003)]
-        wls, flux_rot, _ = synth(; wavelengths=wl_spec, vsini=10)
-        wls_raw, flux_raw, _ = synth(; wavelengths=wl_spec, vsini=0)
+        wls, flux_rot, _ = synth(; default_ps..., wavelengths=wl_spec, vsini=10)
+        wls_raw, flux_raw, _ = synth(; default_ps..., wavelengths=wl_spec, vsini=0)
         @assert wls == wls_raw
         flux_manual_rot = Korg.apply_rotation(flux_raw, wl_spec, 10)
         @test flux_rot ≈ flux_manual_rot
@@ -36,7 +37,8 @@
 
     @testset "abundances" begin
         # Test that abundance changes match direct synthesize calls
-        wls, flux, _ = synth(; wavelengths=(5000, 5001), m_H=-0.5, alpha_H=0.4, C=-0.3)
+        wls, flux, _ = synth(; default_ps..., wavelengths=(5000, 5001), m_H=-0.5, alpha_H=0.4,
+                             C=-0.3)
 
         atm = interpolate_marcs(5000, 4.5, format_A_X(-0.5, 0.4, Dict("C" => -0.3)))
         sol = synthesize(atm, default_linelist, format_A_X(-0.5, 0.4, Dict("C" => -0.3)), 5000,
@@ -48,7 +50,7 @@
 
     @testset "atmospheric parameters" begin
         # Test that Teff and logg changes match direct synthesize calls
-        wls, flux, _ = synth(; wavelengths=(5000, 5001), Teff=4500, logg=2.5)
+        wls, flux, _ = synth(; default_ps..., wavelengths=(5000, 5001), Teff=4500, logg=2.5)
 
         atm = interpolate_marcs(4500, 2.5, format_A_X())
         sol = synthesize(atm, default_linelist, format_A_X(), 5000, 5001)
@@ -58,21 +60,21 @@
     end
 
     @testset "microturbulence" begin
-        wls, flux, _ = synth(; wavelengths=(5000, 5001), vmic=2.0)
+        wls, flux, _ = synth(; default_ps..., wavelengths=(5000, 5001), vmic=2.0)
         sol = synthesize(default_atm, default_linelist, format_A_X(), 5000, 5001; vmic=2.0)
         @test flux ≈ sol.flux ./ sol.cntm
     end
 
     @testset "linelist" begin
         linelist = []
-        wls, flux, _ = synth(; wavelengths=(5000, 5001), linelist=linelist)
+        wls, flux, _ = synth(; default_ps..., wavelengths=(5000, 5001), linelist=linelist)
         sol = synthesize(default_atm, linelist, format_A_X(), 5000, 5001)
         @test flux ≈ sol.flux ./ sol.cntm
     end
 
     @testset "parameter passing" begin
         # Test that synthesize_kwargs are properly passed through
-        wls, flux, _ = synth(; wavelengths=(5000, 5001),
+        wls, flux, _ = synth(; default_ps..., wavelengths=(5000, 5001),
                              synthesize_kwargs=Dict(:vmic => 2.0))
 
         sol = synthesize(default_atm, default_linelist, format_A_X(), 5000, 5001; vmic=2.0)


### PR DESCRIPTION
It's basically never the case that you don't care what Teff and logg get used.  Not specifying them is almost always a mistake, so it should throw an error.

The R=Inf case is now handled in apply_LSF rather than synth, which is more consistent.

closes #454 