### PR TITLE
image syntax that github readme and documenter.jl both understand

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ plot(wls, flux, "k-")
 xlabel(L"$\lambda$ [Å]")
 ylabel(L"$F_\lambda/R_\mathrm{star}^2$ [erg s$^{-1}$ cm$^{-5}$]");
 ```
-<img src="https://github.com/ajwheeler/Korg.jl/assets/711963/70a13b45-4db2-472c-9121-fdd818a47105" />
+![spectrum](https://github.com/ajwheeler/Korg.jl/assets/711963/70a13b45-4db2-472c-9121-fdd818a47105)
 
 See the [documentation for `synth`](https://ajwheeler.github.io/Korg.jl/stable/API/#Korg.synth), or [the documentation for `synthesize`](https://ajwheeler.github.io/Korg.jl/stable/API/#Korg.synth) for advanced usage.
 


### PR DESCRIPTION
This is relevant because the README is coppied as index.md docs.

#474 attempted to fix this but it didn't work. I'm 99% sure that this will.