### PR TITLE
Specify that `save_molecular_cross_section` uses HDF5

### DIFF
--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -112,7 +112,7 @@ end
 """
     save_molecular_cross_section(filename, cross_section)
 
-Save a precomputed molecular cross-section to a file.
+Save a precomputed molecular cross-section to an HDF5 file.
 See also [`MolecularCrossSection`](@ref), [`read_molecular_cross_section`](@ref).
 
 !!! warning


### PR DESCRIPTION
fixes #485