### PR TITLE
Load atmosphere archive on package load.

### DIFF
--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -316,7 +316,6 @@ end
 _cool_dwarfs_atm_itp = nothing
 function _get_cool_dwarfs_atm_itp()
     if isnothing(_cool_dwarfs_atm_itp)
-        println("Constructing cool dwarf atmosphere interpolator.  This will only happen once per process...")
         path = joinpath(artifact"resampled_cool_dwarf_atmospheres",
                         "resampled_cool_dwarf_atmospheres",
                         "resampled_cool_dwarf_atmospheres.h5")
@@ -327,6 +326,7 @@ function _get_cool_dwarfs_atm_itp()
     end
     _cool_dwarfs_atm_itp
 end
+_get_cool_dwarfs_atm_itp() # run this on package load
 
 struct AtmosphereInterpolationError <: Exception
     msg::String


### PR DESCRIPTION
This should be precompiled away for most workflows, which will save people a lot of time. I'm also sensitive to how many steps have large latency when using korg.py, and would like to concetrate waiting to as few as possible.