### PR TITLE
Make the vec-of-tuples method of Wavelengths slightly more permissive

### DIFF
--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -97,10 +97,9 @@ function Wavelengths(wls::AbstractVector; tolerance=1e-6, kwargs...)
     end
 end
 # this handles the vector-of-bounds case. Each element can be a tuple of (λ_start, λ_stop) or
-# (λ_start, λ_stop, λ_step).
-function Wavelengths(tuples::AbstractVector{<:Union{<:Tuple{<:Real,<:Real},
-                                                    <:Tuple{<:Real,<:Real,<:Real}}},
-                     ; kwargs...)
+# (λ_start, λ_stop, λ_step). We don't enforce tuple size here in order to make sure that  literals
+# pass correctly.
+function Wavelengths(tuples::AbstractVector{<:Tuple{Vararg{<:Real}}}, ; kwargs...)
     ranges = map(tuples) do tuple
         if !(2 .<= length(tuple) .<= 3)
             throw(ArgumentError("Each wavelength range must be specified as a tuple of (λ_start, λ_stop) or (λ_start, λ_stop, λ_step). Got $tuple."))

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -30,6 +30,14 @@
         @test Korg.Wavelengths((15000, 15500, 1.0)) ≈ Korg.Wavelengths((15000, 15500, 1))
         @test Korg.Wavelengths((15000, 15500, 1)) ≈ Korg.Wavelengths(15000:1.0:15500)
 
+        @test Korg.Wavelengths([(5000, 5010), (6000, 6010, 0.02)]) ==
+              Korg.Wavelengths([5000:0.01:5010, 6000:0.02:6010])
+
+        @test_throws ArgumentError Korg.Wavelengths(15000:0.01:15500; air_wavelengths=true,
+                                                    wavelength_conversion_warn_threshold=1e-20)
+    end
+
+    @testset "air/vacuum conversion" begin
         # test automatic air to vacuum conversion
         air_wls = Korg.air_to_vacuum.(15000:0.1:15003)
         test_spec = [
@@ -42,9 +50,6 @@
             test_wls = Korg.Wavelengths(wls; air_wavelengths=true).wl_ranges[1] * 1e8
             @test assert_allclose(test_wls, air_wls; atol=1e-4, print_rachet_info=false)
         end
-
-        @test_throws ArgumentError Korg.Wavelengths(15000:0.01:15500; air_wavelengths=true,
-                                                    wavelength_conversion_warn_threshold=1e-20)
     end
 
     @testset "subspectrum_indices" begin


### PR DESCRIPTION
Literals (such as the one in the new test) often get interpreted as a Vector with a type signature involving Vararg, which was causing dispatch to choose the "vec-of-wl-values" method.  I found this working on korg.py.