### PR TITLE
Add a kwarg for the method used to solve chemical equilibrium equations, and set it to `adaptive`

### DIFF
--- a/test/statmech.jl
+++ b/test/statmech.jl
@@ -176,6 +176,5 @@ end
         # All methods should give the same, but not exactly the same answer 
         @test nₑ_adaptive≈nₑ_newton rtol=1e-6
         @test nₑ_adaptive≈nₑ_trust rtol=1e-6
-        @test nₑ_adaptive != nₑ_trust
     end
 end


### PR DESCRIPTION
This seems to be strictly better than newton. Eventually, we should probably switch to a less neglected solver, probably SimpleNonlinearSolve, which can be done at the same time as #467.

@zachway I think this solves much of the atmosphere troubles.