### PR TITLE
Use `expm1` in blackbody function

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -401,5 +401,5 @@ function blackbody(T, λ)
     c = c_cgs
     k = kboltz_cgs
 
-    2 * h * c^2 / λ^5 * 1 / (exp(h * c / λ / k / T) - 1)
+    2 * h * c^2 / λ^5 * 1 / expm1(h * c / λ / k / T)
 end


### PR DESCRIPTION
Hi all, thanks for this package! This is probably the smallest PR to ever PR, but I just happened to notice this while shutting things down in [Planck.jl](https://github.com/JuliaAstro/Planck.jl) over in JuliaAstro, in case it is useful