### PR TITLE
use less memory when loading ExoMol linelists

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Korg"
 uuid = "acafc109-a718-429c-b0e5-afd7f8c7ae46"
-authors = ["Adam Wheeler <adamwhlr@gmail.com>", "Matthew Abruzzo <matthewabruzzo@gmail.com>"]
 version = "1.0.1"
+authors = ["Adam Wheeler <adamwhlr@gmail.com>", "Matthew Abruzzo <matthewabruzzo@gmail.com>"]
 
 [workspace]
 projects = ["test", "benchmark", "docs"]
@@ -10,7 +10,6 @@ projects = ["test", "benchmark", "docs"]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
@@ -28,14 +27,12 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]
 CSV = "0.8, 0.9, 0.10"
 Compat = "4.10 - 4"
 DSP = "0.7, 0.8"
-DataFrames = "1.7.0"
 DiffResults = "1"
 FITSIO = "0.17.5"
 FastGaussQuadrature = "0.4, 0.5, 1"
@@ -53,6 +50,5 @@ SparseArrays = "1.7 - 1"
 SpecialFunctions = "1.4, 2"
 StaticArrays = "1"
 Statistics = "1"
-TableOperations = "1.2.0"
 Trapz = "2"
 julia = "1.10 - 1"

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -1,6 +1,5 @@
 using CSV, HDF5, LazyArtifacts
 using Pkg.Artifacts: @artifact_str
-using ProgressMeter
 
 #This type represents an individual line.
 struct Line{F1,F2,F3,F4,F5,F6}
@@ -238,17 +237,14 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, lower_wavelen
     wn_lower_limit = 1.0 / (upper_wavelength * 1e-8)
     wn_upper_limit = 1.0 / (lower_wavelength * 1e-8)
 
-    # Load the states file. Exomol files have various number of columns, but the
-    # first three (the only ones we need) seem to be consistent: id, wavenumber, g.
-    level_wns = Float64[]
-    level_gs = Float64[]
+    #  ExoMol files have various numbers of columns, but the first three (the
+    #  only ones we need) are consistent: id, wavenumber, g.
+    states = Dict{Int,Tuple{Float64,Float64}}()
     for row in CSV.File(states_file; delim=" ", ignorerepeated=true, header=false)
         id = Int(row.Column1)
-        @assert id == length(level_wns) + 1
         wavenumber = Float64(row.Column2)
-        push!(level_wns, wavenumber)
         g = Float64(row.Column3)
-        push!(level_gs, g)
+        states[id] = (wavenumber, g)
     end
 
     # Precompute isotopic correction
@@ -273,7 +269,7 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, lower_wavelen
 
     # Stream the transitions file line by line to avoid loading the entire file into memory.
     # This is critical for large ExoMol files, which can be 10s of GB.
-    # most lines will be too weak, or outside the wavelength limits
+    # Most lines will be too weak, or outside the wavelength limits.
     lines = Line{Float64,Float64,Float64,Float64,Float64,Float64}[]
     n_total = 0
     n_unmapped = 0 # collect for error message
@@ -282,13 +278,13 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, lower_wavelen
         id_lower = Int(row.Column2)
         A = Float64(row.Column3)
 
-        if !(1 <= id_upper <= length(level_wns)) || !(1 <= id_lower <= length(level_wns))
+        if !haskey(states, id_upper) || !haskey(states, id_lower)
             n_unmapped += 1
             continue
         end
 
-        wn_upper = level_wns[id_upper]
-        wn_lower = level_wns[id_lower]
+        wn_upper, g_upper = states[id_upper]
+        wn_lower, g_lower = states[id_lower]
         wavenumber = wn_upper - wn_lower
 
         # Skip lines outside the wavelength range
@@ -297,12 +293,9 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, lower_wavelen
             continue
         end
 
-        g_upper = level_gs[id_upper]
-        g_lower = level_gs[id_lower]
-
-        # assemble Line object
+        # Assemble Line object
         f = A * prefactor * g_upper / (g_lower * wavenumber^2)
-        log_gf = log10(g_lower * f)
+        log_gf = log10(g_lower * f) + isotopic_correction
         E_lower = Korg.hplanck_eV * wn_lower * Korg.c_cgs
         line = Korg.Line(1.0 / wavenumber, log_gf, spec, E_lower)
 

--- a/src/linelist.jl
+++ b/src/linelist.jl
@@ -1,6 +1,6 @@
-using CSV, HDF5, LazyArtifacts, TableOperations
-using DataFrames: DataFrame, leftjoin, leftjoin!, rename!
+using CSV, HDF5, LazyArtifacts
 using Pkg.Artifacts: @artifact_str
+using ProgressMeter
 
 #This type represents an individual line.
 struct Line{F1,F2,F3,F4,F5,F6}
@@ -204,17 +204,25 @@ Load a linelist from ExoMol. Returns a vector of [`Line`](@ref)s, the same as [`
   - `line_strength_cutoff`: the cutoff for the line strength (default: -15) used to filter the
     linelist. See [`approximate_line_strength`](@ref) for more information.
   - `T_line_strength`: the temperature (K) at which to evaluate the line strength (default: 3500.0)
-  - `isotopic_abundances`: the table of isotopic abundances to use (default: `Korg.isotopic_abundances`).
-    This is ignored if `isotopic_correction` is provided.
-  - `verbose`: if `true` (default), will print progress information to the console.
+
+  - `isotopic_abundances`: the table of isotopic abundances to use (default: `Korg.isotopic_abundances`).  This is ignored if `isotopic_correction` is provided.
+  - `verbose`: if `true` (default), will print progress information
+
+# Returns
+
+A linelist, as a vector of [`Line`](@ref)s.
+
 
 !!! warning
 
     This functionality is in beta. It's behavior may change without a major version number bump.
 """
-function load_ExoMol_linelist(spec, states_file, transitions_file, ll, ul;
+function load_ExoMol_linelist(spec, states_file, transitions_file, lower_wavelength,
+                              upper_wavelength;
                               isotopes=nothing, isotopic_abundances=Korg.isotopic_abundances,
-                              line_strength_cutoff=-15, T_line_strength=3500.0, verbose=true)
+                              line_strength_cutoff=-15, T_line_strength=3500.0,
+                              verbose=true)::Vector{Line{Float64,Float64,Float64,Float64,Float64,
+                                                         Float64}}
     if spec isa AbstractString
         spec = Species(spec)
     end
@@ -226,41 +234,28 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, ll, ul;
         @info "The states and transitions files, $states_file and $transitions_file, don't contain the string 'states' or 'trans', respectively. You may have mixed them up."
     end
 
-    # These contortions allow us to read only the first N columns, without parsing the rest.
-    # This is (probably) faster, and more memory efficient. But also the ExoMol files sometimes
-    # have various extra columns. Hopefully we can cound on the first three being consistent.
-    raw_transitions = CSV.File(transitions_file; delim=" ", ignorerepeated=true, header=false) |>
-                      TableOperations.select(:Column1, :Column2, :Column3) |>
-                      DataFrame
-    rename!(raw_transitions, :Column1 => :id_upper, :Column2 => :id_lower, :Column3 => :A)
-    states = CSV.File(states_file; delim=" ", ignorerepeated=true, header=false) |>
-             TableOperations.select(:Column1, :Column2, :Column3) |>
-             DataFrame
-    rename!(states, :Column1 => :id, :Column2 => :E_wavenumber, :Column3 => :g)
+    # convert wavelength limits in Å to wavenumber limits in cm^-1
+    wn_lower_limit = 1.0 / (upper_wavelength * 1e-8)
+    wn_upper_limit = 1.0 / (lower_wavelength * 1e-8)
 
-    # join the transitions and states tables on the id column to get the upper and lower level info
-    transitions = leftjoin(raw_transitions, states; on=:id_upper => :id)
-    rename!(transitions, :E_wavenumber => :wavenumber_upper, :g => :g_upper)
-    leftjoin!(transitions, states; on=:id_lower => :id)
-    rename!(transitions, :E_wavenumber => :wavenumber_lower, :g => :g_lower)
-
-    # if the column is missing, the join didn't find a matching state
-    if any(ismissing.(transitions.g_lower)) || any(ismissing.(transitions.g_upper))
-        throw(ArgumentError("Some of the transitions in $transitions_file can't be mapped to states in $states_file"))
+    # Load the states file. Exomol files have various number of columns, but the
+    # first three (the only ones we need) seem to be consistent: id, wavenumber, g.
+    level_wns = Float64[]
+    level_gs = Float64[]
+    for row in CSV.File(states_file; delim=" ", ignorerepeated=true, header=false)
+        id = Int(row.Column1)
+        @assert id == length(level_wns) + 1
+        wavenumber = Float64(row.Column2)
+        push!(level_wns, wavenumber)
+        g = Float64(row.Column3)
+        push!(level_gs, g)
     end
 
-    # Gray 4th ed, eq 11.12 (page 214) but with an extra factor of 1/4π for stradian vs unit sphere.
-    # Difference of 1e16 is due to Å vs cm
-    prefactor = (Korg.electron_mass_cgs * Korg.c_cgs) / (8π^2 * Korg.electron_charge_cgs^2)
-
-    transitions.wavenumber = transitions.wavenumber_upper .- transitions.wavenumber_lower
-    transitions.f = @. transitions.A * prefactor * transitions.g_upper /
-                       (transitions.g_lower * transitions.wavenumber^2)
-    transitions.log_gf = log10.(transitions.g_lower .* transitions.f)
-
-    # perform isotopic correction to log gf values
+    # Precompute isotopic correction
     if isnothing(isotopes)
-        verbose && println("Assuming the most abundant isotope for all atoms.")
+        verbose &&
+            println("Assuming the most abundant isotope for all atoms. " *
+                    "Use the isotopes keyword argument to specify otherwise.")
         isotopes = map(get_atoms(spec)) do Z
             (Z, argmax(isotopic_abundances[Z]))
         end
@@ -272,28 +267,65 @@ function load_ExoMol_linelist(spec, states_file, transitions_file, ll, ul;
     isotopic_correction -= log10(prod(isotopic_nuclear_spin_degeneracies[Z][iso]
                                       for (Z, iso) in isotopes))
 
-    transitions.log_gf .+= isotopic_correction
+    # Gray 4th ed, eq 11.12 (page 214) but with an extra factor of 1/4π for stradian vs unit sphere.
+    # Difference of 1e16 is due to Å vs cm
+    prefactor = (Korg.electron_mass_cgs * Korg.c_cgs) / (8π^2 * Korg.electron_charge_cgs^2)
 
-    transitions.E_lower = @. Korg.hplanck_eV * transitions.wavenumber_lower * Korg.c_cgs
-    transitions.wavelength = 1.0 ./ transitions.wavenumber
+    # Stream the transitions file line by line to avoid loading the entire file into memory.
+    # This is critical for large ExoMol files, which can be 10s of GB.
+    # most lines will be too weak, or outside the wavelength limits
+    lines = Line{Float64,Float64,Float64,Float64,Float64,Float64}[]
+    n_total = 0
+    n_unmapped = 0 # collect for error message
+    for row in CSV.File(transitions_file; delim=" ", ignorerepeated=true, header=false)
+        id_upper = Int(row.Column1)
+        id_lower = Int(row.Column2)
+        A = Float64(row.Column3)
 
-    region = transitions[ll.<transitions.wavelength.*1e8.<ul, :]
+        if !(1 <= id_upper <= length(level_wns)) || !(1 <= id_lower <= length(level_wns))
+            n_unmapped += 1
+            continue
+        end
 
-    lines = map(eachrow(region)) do row
-        Korg.Line(row.wavelength, row.log_gf, spec, row.E_lower)
-    end |> reverse
+        wn_upper = level_wns[id_upper]
+        wn_lower = level_wns[id_lower]
+        wavenumber = wn_upper - wn_lower
 
-    # if there's nothing left, stop processing
-    if isempty(lines)
-        return lines
+        # Skip lines outside the wavelength range
+        if wavenumber <= 0 || wavenumber < wn_lower_limit || wavenumber > wn_upper_limit
+            n_total += 1
+            continue
+        end
+
+        g_upper = level_gs[id_upper]
+        g_lower = level_gs[id_lower]
+
+        # assemble Line object
+        f = A * prefactor * g_upper / (g_lower * wavenumber^2)
+        log_gf = log10(g_lower * f)
+        E_lower = Korg.hplanck_eV * wn_lower * Korg.c_cgs
+        line = Korg.Line(1.0 / wavenumber, log_gf, spec, E_lower)
+
+        n_total += 1
+
+        # Filter by line strength immediately to avoid accumulating weak lines
+        if approximate_line_strength(line, T_line_strength) > line_strength_cutoff
+            push!(lines, line)
+        end
     end
 
-    # Remove weak lines
-    mask = approximate_line_strength.(lines, T_line_strength) .> line_strength_cutoff
-    if verbose
-        println("Removed $(sum(.!mask)) lines with strength below $line_strength_cutoff at T = $T_line_strength K out of $(length(lines)) total lines ($(round(Int, 100 * sum(.!mask) / length(lines)))%).")
+    if n_unmapped > 0
+        throw(ArgumentError("Some of the transitions in $transitions_file can't be mapped to states in $states_file"))
     end
-    lines = lines[mask]
+
+    if n_total == 0 && verbose
+        println("no lines between $upper_wavelength Å and $lower_wavelength Å")
+    elseif isempty(lines) && verbose
+        println("All $n_total lines removed as too weak (strength below $line_strength_cutoff at T = $T_line_strength K)")
+    elseif verbose
+        n_removed = n_total - length(lines)
+        println("Removed $n_removed lines with strength below $line_strength_cutoff at T = $T_line_strength K out of $n_total total lines ($(round(Int, 100 * n_removed / n_total))%).")
+    end
 
     sort!(lines; by=l -> l.wl)
     lines


### PR DESCRIPTION
Don't instantiate dataframes when loading exomol linelists. That was a kind of lazy implementation.  It uses way more memory than necessary.

closes #393, hopefully.  There's always room for improvement, but this should bring it with a factor of a few of the optimal memory use.