### PR TITLE
Remove macOS/Windows CI runners and update setup-julia to v3.0.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: julia-actions/setup-julia@v2.7.0
+      - uses: julia-actions/setup-julia@v3.0.2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,6 @@ jobs:
           - "1"
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/TestNightly.yml
+++ b/.github/workflows/TestNightly.yml
@@ -23,7 +23,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: julia-actions/setup-julia@v2.7.0
+      - uses: julia-actions/setup-julia@v3.0.2
         with:
           version: nightly
           arch: ${{ matrix.arch }}

--- a/.github/workflows/TestNightly.yml
+++ b/.github/workflows/TestNightly.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
macOS runners switched to Apple Silicon (arm64) but the workflows specified `arch: x64`, causing failures. Since Korg.jl is pure Julia with no platform-specific C deps, cross-platform runners add little value — Linux catches everything that matters.

- Remove macOS and Windows from the CI and TestNightly matrices (keep only `ubuntu-latest`)
- Update `julia-actions/setup-julia` from v2.7.0 to v3.0.2 in both workflows

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDfWpV8uvAsJMS2ccc3g8f)_