### PR TITLE
Don't run benchmarks on every PR

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,8 +1,6 @@
 name: Benchmark
 
 on:
-  pull_request:
-    branches: [ main ]   # change if your default branch differs
   workflow_dispatch:     # allows manual triggering for PRs from forks
 
 permissions:


### PR DESCRIPTION
Removed pull_request trigger from benchmark workflow.