### PR TITLE
Gate benchmark workflow behind run-benchmarks label

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -2,6 +2,7 @@ name: Benchmark
 
 on:
   pull_request:
+    types: [ opened, synchronize, labeled ]
     branches: [ main ]   # change if your default branch differs
   workflow_dispatch:     # allows manual triggering for PRs from forks
 
@@ -11,6 +12,7 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
     strategy:
       matrix:
         julia-version: ["1"] # could also add 1.10 (LTS), but not needed


### PR DESCRIPTION
## Summary
- Trigger the benchmark workflow on `opened`, `synchronize`, and `labeled` PR events instead of the broad default `pull_request` trigger
- Gate the `bench` job with `if: contains(github.event.pull_request.labels.*.name, 'run-benchmarks')` so the benchmark only runs when the PR has the `run-benchmarks` label
- The comment-posting step (`AirspeedVelocity.jl` action) is unchanged

## Test plan
- [ ] Verify the workflow does not trigger benchmarks on a PR without the `run-benchmarks` label
- [ ] Verify the workflow runs the benchmark job when the `run-benchmarks` label is added


---
_Generated by [Claude Code](https://claude.ai/code/session_012YwQPUdTFf958ULonvihZk)_