### PR TITLE
Don't precompute vmic in `MolecularCrossSection`s

### DIFF
--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -1,5 +1,4 @@
 using Interpolations: interpolate!, Gridded, Linear, extrapolate
-using SparseArrays: rowvals, nzrange
 using HDF5
 
 struct MolecularCrossSection
@@ -37,8 +36,8 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
     same species.
   - `wl_param`: Parameters specifying the wavelengths in the same format that [`synthesize`](@ref)
     expects.  Because microturbulence is applied by convolution at synthesis time, the wavelength range of
-    the cross-section should extend a few Å beyond the range you plan to synthesize.
-    Otherwise absorption from just outside the table will be missing near its edges.
+    the cross-section should extend a few Å beyond the range you plan to synthesize.  Otherwise 
+    absorption from just outside the table will be missing near its edges.
 
 # Keyword Arguments
 
@@ -132,7 +131,10 @@ Evaluate the molecular cross-sections at each wavelength and layer and add them 
 absorption coefficient, `α`.
 
 Microturbulent broadening is applied via (sparse) matrix multiplication (convolution in velocity
-space), extending `vmic_window_size` standard deviations from the center.
+space), with a kernel extending `vmic_window_size` standard deviations from the center.  The
+cross-section wavelengths must be sampled at least as finely as `λs` (an `ArgumentError` is thrown
+otherwise).  For microturbulence values so small that the kernel is narrower than the table spacing,
+broadening is negligible and the cross-section is interpolated directly.
 
 See [`MolecularCrossSection`](@ref) for more information.
 """
@@ -143,6 +145,10 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
         return
     end
     n_layers = size(α, 1)
+
+    # Get the finest synthesis wavelength spacing, used to check that each table is sampled at least
+    # as finely.  Single-wavelength requests (e.g. just the reference wavelength) are allowed.
+    synth_steps = [step(r) for r in λs.wl_ranges if length(r) > 1]
 
     for sigma in molecular_cross_sections
         n_species = number_densities[sigma.species]
@@ -159,12 +165,22 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
             continue
         end
 
+        cross_section_max_step = maximum(step, sigma.wls.wl_ranges)
+        if !isempty(synth_steps) && cross_section_max_step > minimum(synth_steps) * (1 + 1e-10)
+            throw(ArgumentError("the molecular cross-section for $(sigma.species) is more coarsely " *
+                                "sampled ($(round(cross_section_max_step * 1e8; sigdigits=3)) Å) than the " *
+                                "synthesis wavelengths ($(round(minimum(synth_steps) * 1e8; sigdigits=3)) Å). " *
+                                "Regenerate it with spacing no coarser than the synthesis grid."))
+        end
+
+        # Below this microturbulence value, the convolution kernel is narrower than the table
+        # spacing, so we interpolate the table directly. Note that the vmic partials are exactly 0.
+        vmic_threshold = 1e-5 * sqrt(2) * c_cgs * cross_section_max_step / (2 * vmic_window_size * first(sigma.wls))
+
         # one broadening matrix per unique vmic value, shared across layers
         unique_vmics = vmic isa Number ? [vmic] : unique(vmic)
         for vm in unique_vmics
-            # at vmic == 0 the kernel is a delta function, so interpolate directly.
-            # when vmic == 0, ∂α/∂vmic == 0 as well, so it's legit to drop any partials of vmic
-            if vm == 0
+            if vm <= vmic_threshold
                 for i in 1:n_layers
                     (vmic isa Number ? vmic : vmic[i]) == vm || continue
                     α[i, :] .+= sigma.itp.(log10(Ts[i]), λs) * n_species[i]
@@ -172,36 +188,22 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
                 continue
             end
 
-            # Use the LSF machinery to compure a sparse matrix that applies a velocity-space 
+            # It's faster to do this calculation with only the wavelengths required (mostly to avoid 
+            # unecessary interpolation from the cross-section table). sub_wls is a Wavelengths 
+            # object to serve as the common axis between the broadening matrix and the interpolated 
+            # cross section values.
+            σ_max = last(λs) * vm * 1e5 / (sqrt(2) * c_cgs)
+            sub_wls = subset(sigma.wls, λs; pad=vmic_window_size * σ_max + cross_section_max_step)
+            isnothing(sub_wls) && continue # no table points are within reach of any kernel
+
+            # Use the LSF machinery to compute a sparse matrix that applies a velocity-space
             # gaussian convolution and resamples from the cross-section λs to the synthesis λs.
-            vmic_matrix = compute_LSF_matrix(sigma.wls, λs, _vmic_equivalent_R(vm * 1e5);
-                                   window_size=vmic_window_size, verbose=false)
-
-            # keep track of which wavelengths get nothing from the matrix, becaue they are outside 
-            # the precomputed cross-section's wavelength regions
-            row_has_kernel = falses(length(λs))
-            row_has_kernel[rowvals(vmic_matrix)] .= true
-            fallback_inds = findall(!, row_has_kernel)
-
-            # restrict the matrix product to the table columns under some kernel.  This makes
-            # requests for a few wavelengths (α at the reference wavelength for anchored radiative
-            # transfer) cheap: only a small piece of the table is interpolated per layer.
-            cols = let nonempty = j -> !isempty(nzrange(vmic_matrix, j))
-                first_col = findfirst(nonempty, 1:size(vmic_matrix, 2))
-                isnothing(first_col) ? (1:0) : (first_col:findlast(nonempty, 1:size(vmic_matrix, 2)))
-            end
-            Msub = vmic_matrix[:, cols]
-            sub_wls = sigma.wls[cols]
+            vmic_matrix = compute_LSF_matrix(sub_wls, λs, _vmic_equivalent_R(vm * 1e5);
+                                             window_size=vmic_window_size, verbose=false)
 
             for i in 1:n_layers
                 (vmic isa Number ? vmic : vmic[i]) == vm || continue
-                logT = log10(Ts[i])
-                if !isempty(cols)
-                    α[i, :] .+= (Msub * sigma.itp.(logT, sub_wls)) .* n_species[i]
-                end
-                for j in fallback_inds
-                    α[i, j] += sigma.itp(logT, λs[j]) * n_species[i]
-                end
+                α[i, :] .+= (vmic_matrix * sigma.itp.(log10(Ts[i]), sub_wls)) .* n_species[i]
             end
         end
     end

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -1,4 +1,5 @@
 using Interpolations: interpolate!, Gridded, Linear, extrapolate
+using SparseArrays: rowvals, nzrange
 using HDF5
 
 struct MolecularCrossSection
@@ -6,6 +7,20 @@ struct MolecularCrossSection
     itp
     species::Korg.Species
 end
+
+const _VMIC_GRID_DEPRECATION_MSG = "vmic-gridded molecular cross-sections are deprecated. " *
+                                   "Microturbulence is now applied by convolving a vmic=0 cross-section at synthesis time, " *
+                                   "which is faster to precompute, smaller to store, and more accurate for vmic values off " *
+                                   "the precomputation grid.  Regenerate your cross-section with " *
+                                   "MolecularCrossSection(linelist, wls) (without vmic_vals) to use the new format."
+
+"""
+    is_vmic_gridded(cross_section)
+
+Whether a [`MolecularCrossSection`](@ref) is in the deprecated format which grids over vmic, rather
+than the current format, which is computed at vmic=0 and broadened at synthesis time.
+"""
+is_vmic_gridded(σ::MolecularCrossSection) = length(σ.itp.itp.knots) == 3
 
 """
     MolecularCrossSection(linelist, wl_params...; kwargs...)
@@ -21,16 +36,19 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
   - `linelist`: A vector of `Line` objects representing the molecular linelist.  These must be of the
     same species.
   - `wl_param`: Parameters specifying the wavelengths in the same format that [`synthesize`](@ref)
-    expects.
+    expects.  Because microturbulence is applied by convolution at synthesis time, the wavelength range of
+    the cross-section should extend a few Å beyond the range you plan to synthesize.
+    Otherwise absorption from just outside the table will be missing near its edges.
 
 # Keyword Arguments
 
   - `cutoff_alpha` (default: 1e-32): The value of the single-line absorption coefficient (in cm^-1) at
     which to truncate the profile.
-  - `vmic_vals` (default: [(0.0:1/3:1.0)...; 1.5; (2:2/3:(5+1/3))...]): The microturbulence velocities
-    at which to precompute the cross-section.
-  - `log_temp_vals` (default: 3:0.025:5): The log10 of the temperatures at which to precompute the
+  - `log_temp_vals` (default: 3:0.04:5): The log10 of the temperatures at which to precompute the
     cross-section.
+  - **deprecated** `vmic_vals` (default: `nothing`): If provided, a vector of microturbulence values
+    (in km/s) at which to precompute the cross-section, producing a table in the deprecated
+    vmic-gridded format (which is interpolated in vmic at synthesis time, rather than convolved).
 
 !!! warning
 
@@ -39,14 +57,13 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
 
 !!! tip
 
-    The default values of `vmic_vals`, `log_temp_vals`, and `cutoff_alpha` were chosen to ensure
-    that lines in the APOGEE linelist ([`get_APOGEE_DR17_linelist`](@ref)) could be accurately
-    reproduced (better than 10^-3 everywhere). You should verify that they yield acceptable accuracy
-    for other applications by comparing spectra synthesize with and without precomputing the
-    molecular cross-section.
+    The default values of `log_temp_vals` and `cutoff_alpha` were chosen to ensure that lines in
+    the APOGEE linelist ([`get_APOGEE_DR17_linelist`](@ref)) could be accurately reproduced (better
+    than 10^-3 everywhere). You should verify that they yield acceptable accuracy for other
+    applications by comparing spectra synthesize with and without precomputing the molecular
+    cross-section.
 """
-function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32,
-                               vmic_vals=[(0.0:1/3:1.0)...; 1.5; (2:2/3:(5+1/3))...],
+function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32, vmic_vals=nothing,
                                log_temp_vals=3:0.04:5)
     wls = Wavelengths(wl_params)
     all_specs = [l.species for l in linelist]
@@ -55,60 +72,137 @@ function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32,
     end
     species = all_specs[1]
 
-    α = zeros(length(vmic_vals), length(log_temp_vals), length(wls))
-
     # set both the continuum absorption coef (cntm) and the cutoff absorption coef to
     # unity.  Handle the cutoff value by scaling the number density of the molecule
     # (in n_dict).
     Ts = 10 .^ log_temp_vals
     nₑ = zeros(length(log_temp_vals))
-    # Korg will compute the effective broadener number density for vdW broadening, which requires 
-    # number density values for H I, He I, and H2. It will not be used, since only molecular lines 
+    # Korg will compute the effective broadener number density for vdW broadening, which requires
+    # number density values for H I, He I, and H2. It will not be used, since only molecular lines
     # are present.
     n_dict = Dict(species => 1 / cutoff_alpha,
                   species"H I" => NaN, species"H2" => NaN, species"He I" => NaN)
-    ξ = 0.0
     cntm = fill(λ -> 1.0, length(log_temp_vals))
 
-    for (i, vmic) in enumerate(vmic_vals)
-        ξ = vmic * 1e5 #km/s to cm/s
-        Korg.line_absorption!(view(α, i, :, :), linelist, wls, Ts, nₑ, n_dict,
-                              Korg.default_partition_funcs, ξ, cntm; cutoff_threshold=1.0)
+    itp = if isnothing(vmic_vals)
+        α = zeros(length(log_temp_vals), length(wls))
+        Korg.line_absorption!(α, linelist, wls, Ts, nₑ, n_dict,
+                              Korg.default_partition_funcs, 0.0, cntm; cutoff_threshold=1.0)
+        extrapolate(interpolate!((log_temp_vals, wls), α .* cutoff_alpha,
+                                 (Gridded(Linear()), Gridded(Linear()))), 0.0)
+    else
+        @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+        α = zeros(length(vmic_vals), length(log_temp_vals), length(wls))
+        for (i, vmic) in enumerate(vmic_vals)
+            ξ = vmic * 1e5 #km/s to cm/s
+            Korg.line_absorption!(view(α, i, :, :), linelist, wls, Ts, nₑ, n_dict,
+                                  Korg.default_partition_funcs, ξ, cntm; cutoff_threshold=1.0)
+        end
+        extrapolate(interpolate!((vmic_vals, log_temp_vals, wls), α .* cutoff_alpha,
+                                 (Gridded(Linear()), Gridded(Linear()), Gridded(Linear()))), 0.0)
     end
-
-    species = all_specs[1]
-    itp = extrapolate(interpolate!((vmic_vals, log_temp_vals, wls), α .* cutoff_alpha,
-                                   (Gridded(Linear()), Gridded(Linear()), Gridded(Linear()))), 0.0)
     MolecularCrossSection(wls, itp, species)
 end
 
 function Base.show(io::IO, sigma::MolecularCrossSection)
-    Tmin, Tmax = round.(Int, 10 .^ sigma.itp.itp.knots[2][[1, end]])
-    vmicmin, vmicmax = round.(Int, sigma.itp.itp.knots[1][[1, end]])
     wlmin, wlmax = round.(Int, sigma.wls[[1, end]] .* 1e8)
-    println(io, "Molecular cross-section for ", sigma.species,
-            " ($(wlmin) Å ≤ λ ≤ $(wlmax) Å, $(Tmin) K ≤ T ≤ $(Tmax) K, $(vmicmin) km/s ≤ vmic ≤ $(vmicmax) km/s)")
+    if is_vmic_gridded(sigma)
+        Tmin, Tmax = round.(Int, 10 .^ sigma.itp.itp.knots[2][[1, end]])
+        vmicmin, vmicmax = round.(Int, sigma.itp.itp.knots[1][[1, end]])
+        println(io, "Molecular cross-section for ", sigma.species,
+                " ($(wlmin) Å ≤ λ ≤ $(wlmax) Å, $(Tmin) K ≤ T ≤ $(Tmax) K, " *
+                "$(vmicmin) km/s ≤ vmic ≤ $(vmicmax) km/s, deprecated vmic-gridded format)")
+    else
+        Tmin, Tmax = round.(Int, 10 .^ sigma.itp.itp.knots[1][[1, end]])
+        println(io, "Molecular cross-section for ", sigma.species,
+                " ($(wlmin) Å ≤ λ ≤ $(wlmax) Å, $(Tmin) K ≤ T ≤ $(Tmax) K)")
+    end
 end
 
-"""
-    interpolate_molecular_cross_sections!(α, molecular_cross_sections, λs, Ts, vmic, number_densities)
+# the equivalent resolving power (R = λ/FWHM) of the microturbulent broadening kernel.
+# Korg's doppler_width convention is σ_λ = λ₀ sqrt(kT/m + ξ²/2)/c, so broadening a vmic=0
+# cross-section to microturbulence ξ requires a Gaussian with velocity width σ_v = ξ/√2.
+_vmic_equivalent_R(ξ) = c_cgs / (2sqrt(log(2)) * ξ)
 
-Interpolate the molecular cross-sections and add them to the total absorption coefficient `α`.
+"""
+    interpolate_molecular_cross_sections!(α, molecular_cross_sections, λs, Ts, vmic, number_densities;
+                                          vmic_window_size=4.0)
+
+Evaluate the molecular cross-sections at each wavelength and layer and add them to the total
+absorption coefficient, `α`.
+
+Microturbulent broadening is applied via (sparse) matrix multiplication (convolution in velocity
+space), extending `vmic_window_size` standard deviations from the center.
+
 See [`MolecularCrossSection`](@ref) for more information.
 """
 function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_cross_sections,
                                                λs::Wavelengths, Ts, vmic,
-                                               number_densities) where R<:Real
+                                               number_densities; vmic_window_size=4.0) where R<:Real
     if length(molecular_cross_sections) == 0
         return
     end
+    n_layers = size(α, 1)
 
     for sigma in molecular_cross_sections
-        # this is an inefficient order in which to write to α, but doing the interpolations this
-        # way uses less memory.
-        for i in 1:size(α, 1)
-            vm = vmic isa Number ? vmic : vmic[i]
-            α[i, :] .+= sigma.itp.(vm, log10(Ts[i]), λs) * number_densities[sigma.species][i]
+        n_species = number_densities[sigma.species]
+
+        # deprecated, backwards-compatible branch
+        if is_vmic_gridded(sigma)
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            # this is an inefficient order in which to write to α, but doing the interpolations
+            # this way uses less memory.
+            for i in 1:n_layers
+                vm = vmic isa Number ? vmic : vmic[i]
+                α[i, :] .+= sigma.itp.(vm, log10(Ts[i]), λs) * n_species[i]
+            end
+            continue
+        end
+
+        # one broadening matrix per unique vmic value, shared across layers
+        unique_vmics = vmic isa Number ? [vmic] : unique(vmic)
+        for vm in unique_vmics
+            # at vmic == 0 the kernel is a delta function, so interpolate directly.
+            # when vmic == 0, ∂α/∂vmic == 0 as well, so it's legit to drop any partials of vmic
+            if vm == 0
+                for i in 1:n_layers
+                    (vmic isa Number ? vmic : vmic[i]) == vm || continue
+                    α[i, :] .+= sigma.itp.(log10(Ts[i]), λs) * n_species[i]
+                end
+                continue
+            end
+
+            # Use the LSF machinery to compure a sparse matrix that applies a velocity-space 
+            # gaussian convolution and resamples from the cross-section λs to the synthesis λs.
+            vmic_matrix = compute_LSF_matrix(sigma.wls, λs, _vmic_equivalent_R(vm * 1e5);
+                                   window_size=vmic_window_size, verbose=false)
+
+            # keep track of which wavelengths get nothing from the matrix, becaue they are outside 
+            # the precomputed cross-section's wavelength regions
+            row_has_kernel = falses(length(λs))
+            row_has_kernel[rowvals(vmic_matrix)] .= true
+            fallback_inds = findall(!, row_has_kernel)
+
+            # restrict the matrix product to the table columns under some kernel.  This makes
+            # requests for a few wavelengths (α at the reference wavelength for anchored radiative
+            # transfer) cheap: only a small piece of the table is interpolated per layer.
+            cols = let nonempty = j -> !isempty(nzrange(vmic_matrix, j))
+                first_col = findfirst(nonempty, 1:size(vmic_matrix, 2))
+                isnothing(first_col) ? (1:0) : (first_col:findlast(nonempty, 1:size(vmic_matrix, 2)))
+            end
+            Msub = vmic_matrix[:, cols]
+            sub_wls = sigma.wls[cols]
+
+            for i in 1:n_layers
+                (vmic isa Number ? vmic : vmic[i]) == vm || continue
+                logT = log10(Ts[i])
+                if !isempty(cols)
+                    α[i, :] .+= (Msub * sigma.itp.(logT, sub_wls)) .* n_species[i]
+                end
+                for j in fallback_inds
+                    α[i, j] += sigma.itp(logT, λs[j]) * n_species[i]
+                end
+            end
         end
     end
 end
@@ -131,8 +225,13 @@ function save_molecular_cross_section(filename, cross_section)
 
     HDF5.h5open(filename, "w") do file
         HDF5.write(file, "wls", [(l[begin], step(l), l[end]) for l in wls.wl_ranges])
-        HDF5.write(file, "vmic_vals", collect(itp.itp.knots[1]))
-        HDF5.write(file, "T_vals", collect(itp.itp.knots[2]))
+        if is_vmic_gridded(cross_section)
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            HDF5.write(file, "vmic_vals", collect(itp.itp.knots[1]))
+            HDF5.write(file, "T_vals", collect(itp.itp.knots[2]))
+        else
+            HDF5.write(file, "T_vals", collect(itp.itp.knots[1]))
+        end
         HDF5.write(file, "vals", itp.itp.coefs)
         HDF5.write(file, "species", string(species))
     end
@@ -153,17 +252,26 @@ See also [`MolecularCrossSection`](@ref).
 function read_molecular_cross_section(filename)
     HDF5.h5open(filename, "r") do file
         wls = map(HDF5.read(file, "wls")) do (start, step, stop)
-            start*1e8:step*1e8:stop*1e8
+            # reconstruct with an explicit length so that floating-point noise in the stored
+            # (cm-scale) endpoints can't add or drop a point
+            n = round(Int, (stop - start) / step) + 1
+            range(start * 1e8, stop * 1e8; length=n)
         end |> Wavelengths
-        vmic_vals = HDF5.read(file, "vmic_vals")
         logT_vals = HDF5.read(file, "T_vals")
         # doesn't actually matter that it's mmaped because it's passed to interpolate!
         alpha_vals = HDF5.readmmap(file["vals"])
         species = Species(HDF5.read(file, "species"))
 
-        itp = extrapolate(interpolate!((vmic_vals, logT_vals, wls), alpha_vals,
-                                       (Gridded(Linear()), Gridded(Linear()), Gridded(Linear()))),
-                          0.0)
+        itp = if haskey(file, "vmic_vals")
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            vmic_vals = HDF5.read(file, "vmic_vals")
+            extrapolate(interpolate!((vmic_vals, logT_vals, wls), alpha_vals,
+                                     (Gridded(Linear()), Gridded(Linear()), Gridded(Linear()))),
+                        0.0)
+        else
+            extrapolate(interpolate!((logT_vals, wls), alpha_vals,
+                                     (Gridded(Linear()), Gridded(Linear()))), 0.0)
+        end
 
         MolecularCrossSection(wls, itp, species)
     end

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -62,7 +62,7 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
     applications by comparing spectra synthesize with and without precomputing the molecular
     cross-section.
 """
-function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32, vmic_vals=nothing,
+function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-26, vmic_vals=nothing,
                                log_temp_vals=3:0.04:5)
     wls = Wavelengths(wl_params)
     all_specs = [l.species for l in linelist]
@@ -85,10 +85,8 @@ function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32, vmic_val
 
     itp = if isnothing(vmic_vals)
         α = zeros(length(log_temp_vals), length(wls))
-        @show size(α)
         Korg.line_absorption!(α, linelist, wls, Ts, nₑ, n_dict,
                               Korg.default_partition_funcs, 0.0, cntm; cutoff_threshold=1.0)
-        @show "opacity calculation done"
         extrapolate(interpolate!((log_temp_vals, wls), α .* cutoff_alpha,
                                  (Gridded(Linear()), Gridded(Linear()))), 0.0)
     else

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -132,9 +132,10 @@ absorption coefficient, `α`.
 
 Microturbulent broadening is applied via (sparse) matrix multiplication (convolution in velocity
 space), with a kernel extending `vmic_window_size` standard deviations from the center.  The
-cross-section wavelengths must be sampled at least as finely as `λs` (an `ArgumentError` is thrown
-otherwise).  For microturbulence values so small that the kernel is narrower than the table spacing,
-broadening is negligible and the cross-section is interpolated directly.
+cross-section is taken to be zero outside the table.  The cross-section wavelengths must be
+sampled at least as finely as `λs` (an `ArgumentError` is thrown otherwise).  For microturbulence
+values so small that the kernel is narrower than the table spacing, broadening is negligible and the
+cross-section is interpolated directly.
 
 See [`MolecularCrossSection`](@ref) for more information.
 """
@@ -200,9 +201,11 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
 
             # a sparse matrix which applies a velocity-space gaussian convolution and resamples
             # from the cross-section λs to the synthesis λs
+            # renormalize=false because the cross-section is treated as zero outside the table
             vmic_broadening_matrix = _gaussian_resample_matrix(sub_wls, λs,
                                                                _vmic_equivalent_R(vm * 1e5);
-                                                               window_size=vmic_window_size)
+                                                               window_size=vmic_window_size,
+                                                               renormalize=false)
 
             for i in 1:n_layers
                 (vmic isa Number ? vmic : vmic[i]) == vm || continue

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -41,7 +41,7 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
 
 # Keyword Arguments
 
-  - `cutoff_alpha` (default: 1e-32): The value of the single-line absorption coefficient (in cm^-1) at
+  - `cutoff_alpha` (default: 1e-26): The value of the single-line absorption coefficient (in cm^-1) at
     which to truncate the profile.
   - `log_temp_vals` (default: 3:0.04:5): The log10 of the temperatures at which to precompute the
     cross-section.
@@ -177,7 +177,7 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
         # Below this microturbulence value, the convolution kernel is narrower than the table
         # spacing, so we interpolate the table directly. Note that the vmic partials are exactly 0.
         vmic_threshold = 1e-5 * sqrt(2) * c_cgs * cross_section_max_step /
-                         (2 * vmic_window_size * first(sigma.wls))
+                         (2 * vmic_window_size * last(sigma.wls))
 
         # one broadening matrix per unique vmic value, shared across layers
         unique_vmics = vmic isa Number ? [vmic] : unique(vmic)

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -85,8 +85,10 @@ function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-32, vmic_val
 
     itp = if isnothing(vmic_vals)
         α = zeros(length(log_temp_vals), length(wls))
+        @show size(α)
         Korg.line_absorption!(α, linelist, wls, Ts, nₑ, n_dict,
                               Korg.default_partition_funcs, 0.0, cntm; cutoff_threshold=1.0)
+        @show "opacity calculation done"
         extrapolate(interpolate!((log_temp_vals, wls), α .* cutoff_alpha,
                                  (Gridded(Linear()), Gridded(Linear()))), 0.0)
     else
@@ -192,18 +194,21 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
             # unecessary interpolation from the cross-section table). sub_wls is a Wavelengths 
             # object to serve as the common axis between the broadening matrix and the interpolated 
             # cross section values.
-            σ_max = last(λs) * vm * 1e5 / (sqrt(2) * c_cgs)
-            sub_wls = subset(sigma.wls, λs; pad=vmic_window_size * σ_max + cross_section_max_step)
+            σ_λ_max = last(λs) * vm * 1e5 / (sqrt(2) * c_cgs)
+            sub_wls = clipped(sigma.wls, λs;
+                              pad=vmic_window_size * σ_λ_max + cross_section_max_step)
             isnothing(sub_wls) && continue # no table points are within reach of any kernel
 
-            # Use the LSF machinery to compute a sparse matrix that applies a velocity-space
-            # gaussian convolution and resamples from the cross-section λs to the synthesis λs.
-            vmic_matrix = compute_LSF_matrix(sub_wls, λs, _vmic_equivalent_R(vm * 1e5);
-                                             window_size=vmic_window_size, verbose=false)
+            # a sparse matrix which applies a velocity-space gaussian convolution and resamples
+            # from the cross-section λs to the synthesis λs
+            vmic_broadening_matrix = _gaussian_resample_matrix(sub_wls, λs,
+                                                               _vmic_equivalent_R(vm * 1e5);
+                                                               window_size=vmic_window_size)
 
             for i in 1:n_layers
                 (vmic isa Number ? vmic : vmic[i]) == vm || continue
-                α[i, :] .+= (vmic_matrix * sigma.itp.(log10(Ts[i]), sub_wls)) .* n_species[i]
+                α[i, :] .+= (vmic_broadening_matrix *
+                             sigma.itp.(log10(Ts[i]), sub_wls)) .* n_species[i]
             end
         end
     end

--- a/src/molecular_cross_sections.jl
+++ b/src/molecular_cross_sections.jl
@@ -36,7 +36,7 @@ this function, though they can be saved and loaded using [`save_molecular_cross_
     same species.
   - `wl_param`: Parameters specifying the wavelengths in the same format that [`synthesize`](@ref)
     expects.  Because microturbulence is applied by convolution at synthesis time, the wavelength range of
-    the cross-section should extend a few Å beyond the range you plan to synthesize.  Otherwise 
+    the cross-section should extend a few Å beyond the range you plan to synthesize.  Otherwise
     absorption from just outside the table will be missing near its edges.
 
 # Keyword Arguments
@@ -90,7 +90,7 @@ function MolecularCrossSection(linelist, wl_params; cutoff_alpha=1e-26, vmic_val
         extrapolate(interpolate!((log_temp_vals, wls), α .* cutoff_alpha,
                                  (Gridded(Linear()), Gridded(Linear()))), 0.0)
     else
-        @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+        @warn _VMIC_GRID_DEPRECATION_MSG maxlog=1
         α = zeros(length(vmic_vals), length(log_temp_vals), length(wls))
         for (i, vmic) in enumerate(vmic_vals)
             ξ = vmic * 1e5 #km/s to cm/s
@@ -155,7 +155,7 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
 
         # deprecated, backwards-compatible branch
         if is_vmic_gridded(sigma)
-            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog=1
             # this is an inefficient order in which to write to α, but doing the interpolations
             # this way uses less memory.
             for i in 1:n_layers
@@ -175,7 +175,8 @@ function interpolate_molecular_cross_sections!(α::AbstractArray{R}, molecular_c
 
         # Below this microturbulence value, the convolution kernel is narrower than the table
         # spacing, so we interpolate the table directly. Note that the vmic partials are exactly 0.
-        vmic_threshold = 1e-5 * sqrt(2) * c_cgs * cross_section_max_step / (2 * vmic_window_size * first(sigma.wls))
+        vmic_threshold = 1e-5 * sqrt(2) * c_cgs * cross_section_max_step /
+                         (2 * vmic_window_size * first(sigma.wls))
 
         # one broadening matrix per unique vmic value, shared across layers
         unique_vmics = vmic isa Number ? [vmic] : unique(vmic)
@@ -231,7 +232,7 @@ function save_molecular_cross_section(filename, cross_section)
     HDF5.h5open(filename, "w") do file
         HDF5.write(file, "wls", [(l[begin], step(l), l[end]) for l in wls.wl_ranges])
         if is_vmic_gridded(cross_section)
-            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog=1
             HDF5.write(file, "vmic_vals", collect(itp.itp.knots[1]))
             HDF5.write(file, "T_vals", collect(itp.itp.knots[2]))
         else
@@ -268,7 +269,7 @@ function read_molecular_cross_section(filename)
         species = Species(HDF5.read(file, "species"))
 
         itp = if haskey(file, "vmic_vals")
-            @warn _VMIC_GRID_DEPRECATION_MSG maxlog = 1
+            @warn _VMIC_GRID_DEPRECATION_MSG maxlog=1
             vmic_vals = HDF5.read(file, "vmic_vals")
             extrapolate(interpolate!((vmic_vals, logT_vals, wls), alpha_vals,
                                      (Gridded(Linear()), Gridded(Linear()), Gridded(Linear()))),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 using Statistics: quantile
 using Interpolations: linear_interpolation, Flat
-using SparseArrays: spzeros
+using SparseArrays: sparse
 
 normal_pdf(Δ, σ) = exp(-0.5 * Δ^2 / σ^2) / √(2π) / σ
 
@@ -122,9 +122,6 @@ Construct a sparse matrix, which when multiplied with a flux vector defined over
 
   - `window_size` (default: 4): how far out to extend the convolution kernel in units of the LSF width (σ, not HWHM)
   - `verbose` (default: `true`): whether or not to emit warnings and information to stdout/stderr.
-  - `step_tolerance`: the maximum difference between adjacent wavelengths in `synth_wls` for them to be
-    considered linearly spaced.  This is only used if `synth_wls` is a vector of wavelengths rather
-    than a range or vector or ranges.
 
 For the best match to data, your wavelength range should extend a couple ``\\Delta\\lambda`` outside
 the region you are going to compare.
@@ -139,18 +136,25 @@ function compute_LSF_matrix(synth_wls, obs_wls, R; window_size=4, verbose=true)
         obs_wls = obs_wls / 1e8 # Å to cm
     end
     synth_wls = Wavelengths(synth_wls)
+
+    tol = 0.01e-8 # 0.01 Å in cm
     if verbose &&
-       !((first(synth_wls) - 0.01) <= first(obs_wls) <= last(obs_wls) <= (last(synth_wls) + 0.01))
+       !((first(synth_wls) - tol) <= first(obs_wls) <= last(obs_wls) <= (last(synth_wls) + tol))
         @warn "Synthesis wavelenths $(synth_wls) are not superset of observation wavelenths" *
               " ($(first(obs_wls)*1e8) Å—$(last(obs_wls)*1e8) Å) in LSF matrix."
     end
-    LSF = spzeros((length(synth_wls), length(obs_wls)))
+
+    # build sparse matrix in COO form (fastest)
+    T = promote_type(eltype(synth_wls), typeof(_resolve_R(R, first(synth_wls))))
+    Is, Js, Vs = Int[], Int[], T[]
     for i in eachindex(obs_wls)
         λ0 = obs_wls[i]
         lb, ub, normalized_ϕ = _lsf_bounds_and_kernel(synth_wls, λ0, R, window_size)
-        LSF[lb:ub, i] .+= normalized_ϕ
+        append!(Is, fill(i, ub - lb + 1))
+        append!(Js, lb:ub)
+        append!(Vs, normalized_ϕ)
     end
-    LSF'
+    sparse(Is, Js, Vs, length(obs_wls), length(synth_wls))
 end
 
 """
@@ -211,10 +215,10 @@ function _apply_rotation_core(flux, wls::StepRangeLen, vsini, ε=0.6)
         ub = searchsortedlast(wls, wls[i] + Δλrot)
         Fwindow = flux[lb:ub]
 
-        detunings = [-Δλrot; (lb-i+1/2:ub-i-1/2) * step(wls); Δλrot]
+        detunings = [-Δλrot; ((lb-i+1/2):(ub-i-1/2)) * step(wls); Δλrot]
 
         ks = _rotation_kernel_integral_kernel.(c1, c2, c3 * Δλrot, detunings, Δλrot)
-        newF[i] = sum(ks[2:end] .* Fwindow) - sum(ks[1:end-1] .* Fwindow)
+        newF[i] = sum(ks[2:end] .* Fwindow) - sum(ks[1:(end-1)] .* Fwindow)
     end
     newF
 end
@@ -317,8 +321,9 @@ Returns a range of indices denoting the elements of `vals` (which are assumed to
 increasing order) that are contained by `interval`. When no entries are contained by interval,
 this returns `(1,0)` (which is a valid empty slice).
 """
-contained_slice(vals::AbstractVector, interval::Interval) = searchsortedfirst(vals, interval.lower):searchsortedlast(vals,
-                                                                                                                     interval.upper)
+function contained_slice(vals::AbstractVector, interval::Interval)
+    searchsortedfirst(vals, interval.lower):searchsortedlast(vals, interval.upper)
+end
 
 function _convert_λ_endpoint(λ_endpoint::AbstractFloat, λ_lower_bound::Bool)
     # determine the functions that:
@@ -353,5 +358,6 @@ end
 Converts a λ `Inverval` (in cm) to an equivalent ν `Interval` (in Hz), correctly accounting for
 tricky floating point details at the bounds.
 """
-λ_to_ν_bound(λ_bound::Interval) = Interval(_convert_λ_endpoint(λ_bound.upper, false),
-                                           _convert_λ_endpoint(λ_bound.lower, true))
+function λ_to_ν_bound(λ_bound::Interval)
+    Interval(_convert_λ_endpoint(λ_bound.upper, false), _convert_λ_endpoint(λ_bound.lower, true))
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,8 +43,14 @@ end
 _resolve_R(R::Real, λ0) = R
 _resolve_R(R::Function, λ0) = R(λ0 * 1e8)  # R is a function of λ in Å
 
-# Core Gaussian-kernel calculation shared by all variants.  
-function _gaussian_bounds_and_kernel(wls::Wavelengths, λ0, R, window_size)
+# `renormalize` controls what happens where `wls` doesn't span the full support
+# of the truncated Gaussian when `renormalize` is true the kernel is divided by
+# its own sum so that it always integrates to exactly 1. For an LSF, where the
+# spectrum continues past the last synthesized wavelength, the points we have
+# are # as good an estimate as we're gonna get. and this make sense For other
+# applying vmic to molecular αs, where the edge of the table is treated at the
+# real edge of the absoption, it's not appropriate.
+function _gaussian_bounds_and_kernel(wls::Wavelengths, λ0, R, window_size; renormalize=true)
     R_val = _resolve_R(R, λ0)
     σ = λ0 / R_val / (2sqrt(2log(2))) # convert Δλ = λ0/R (FWHM) to sigma
 
@@ -52,9 +58,14 @@ function _gaussian_bounds_and_kernel(wls::Wavelengths, λ0, R, window_size)
     lb = searchsortedfirst(wls, λ0 - window_size * σ)
     ub = searchsortedlast(wls, λ0 + window_size * σ)
     @views ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
-    normalized_ϕ = ϕ ./ sum(ϕ)
+    kernel = if renormalize
+        ϕ ./ sum(ϕ)
+    else
+        # multiplying by the local Δλ makes this a quadrature weight rather than a sampled density
+        ϕ .* stepsize.(Ref(wls), lb:ub)
+    end
 
-    lb, ub, normalized_ϕ
+    lb, ub, kernel
 end
 
 """
@@ -150,17 +161,19 @@ end
 # Sparse matrix which convolves a vector defined on `in_wls` with a Gaussian
 # whose FWHM is λ/R(λ), and resamples onto `out_wls` (both in cm). Used by
 # compute_LSF_matrix for the LSF and also for applying vmic to molecular
-# cross-sections.
-function _gaussian_resample_matrix(in_wls::Wavelengths, out_wls, R; window_size=4)
+# cross-sections.  See `_gaussian_bounds_and_kernel` for the meaning of `renormalize`.
+function _gaussian_resample_matrix(in_wls::Wavelengths, out_wls, R; window_size=4,
+                                   renormalize=true)
     # build sparse matrix in COO form (fastest)
     T = promote_type(eltype(in_wls), typeof(_resolve_R(R, first(in_wls))))
     Is, Js, Vs = Int[], Int[], T[]
     for i in eachindex(out_wls)
         λ0 = out_wls[i]
-        lb, ub, normalized_ϕ = _gaussian_bounds_and_kernel(in_wls, λ0, R, window_size)
+        lb, ub, kernel = _gaussian_bounds_and_kernel(in_wls, λ0, R, window_size;
+                                                     renormalize=renormalize)
         append!(Is, fill(i, ub - lb + 1))
         append!(Js, lb:ub)
-        append!(Vs, normalized_ϕ)
+        append!(Vs, kernel)
     end
     sparse(Is, Js, Vs, length(out_wls), length(in_wls))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,19 +39,19 @@ function merge_bounds(bounds, merge_distance=0.0)
 end
 
 # Convert R to a value based on its type
-# used in `_lsf_bounds_and_kernel`
+# used in `_gaussian_bounds_and_kernel`
 _resolve_R(R::Real, λ0) = R
 _resolve_R(R::Function, λ0) = R(λ0 * 1e8)  # R is a function of λ in Å
 
-# Core LSF calculation shared by all variants
-function _lsf_bounds_and_kernel(synth_wls::Wavelengths, λ0, R, window_size)
+# Core Gaussian-kernel calculation shared by all variants.  
+function _gaussian_bounds_and_kernel(wls::Wavelengths, λ0, R, window_size)
     R_val = _resolve_R(R, λ0)
     σ = λ0 / R_val / (2sqrt(2log(2))) # convert Δλ = λ0/R (FWHM) to sigma
 
     # Calculate bounds and kernel
-    lb = searchsortedfirst(synth_wls, λ0 - window_size * σ)
-    ub = searchsortedlast(synth_wls, λ0 + window_size * σ)
-    @views ϕ = normal_pdf.(synth_wls[lb:ub] .- λ0, σ)
+    lb = searchsortedfirst(wls, λ0 - window_size * σ)
+    ub = searchsortedlast(wls, λ0 + window_size * σ)
+    @views ϕ = normal_pdf.(wls[lb:ub] .- λ0, σ)
     normalized_ϕ = ϕ ./ sum(ϕ)
 
     lb, ub, normalized_ϕ
@@ -99,7 +99,7 @@ function apply_LSF(flux::AbstractVector{F}, wls, R; window_size=4) where F<:Real
     convF = zeros(F, length(flux))
     for i in eachindex(wls)
         λ0 = wls[i]
-        lb, ub, normalized_ϕ = _lsf_bounds_and_kernel(wls, λ0, R, window_size)
+        lb, ub, normalized_ϕ = _gaussian_bounds_and_kernel(wls, λ0, R, window_size)
         convF[i] = sum(flux[lb:ub] .* normalized_ϕ)
     end
     convF
@@ -144,17 +144,25 @@ function compute_LSF_matrix(synth_wls, obs_wls, R; window_size=4, verbose=true)
               " ($(first(obs_wls)*1e8) Å—$(last(obs_wls)*1e8) Å) in LSF matrix."
     end
 
+    _gaussian_resample_matrix(synth_wls, obs_wls, R; window_size=window_size)
+end
+
+# Sparse matrix which convolves a vector defined on `in_wls` with a Gaussian
+# whose FWHM is λ/R(λ), and resamples onto `out_wls` (both in cm). Used by
+# compute_LSF_matrix for the LSF and also for applying vmic to molecular
+# cross-sections.
+function _gaussian_resample_matrix(in_wls::Wavelengths, out_wls, R; window_size=4)
     # build sparse matrix in COO form (fastest)
-    T = promote_type(eltype(synth_wls), typeof(_resolve_R(R, first(synth_wls))))
+    T = promote_type(eltype(in_wls), typeof(_resolve_R(R, first(in_wls))))
     Is, Js, Vs = Int[], Int[], T[]
-    for i in eachindex(obs_wls)
-        λ0 = obs_wls[i]
-        lb, ub, normalized_ϕ = _lsf_bounds_and_kernel(synth_wls, λ0, R, window_size)
+    for i in eachindex(out_wls)
+        λ0 = out_wls[i]
+        lb, ub, normalized_ϕ = _gaussian_bounds_and_kernel(in_wls, λ0, R, window_size)
         append!(Is, fill(i, ub - lb + 1))
         append!(Js, lb:ub)
         append!(Vs, normalized_ϕ)
     end
-    sparse(Is, Js, Vs, length(obs_wls), length(synth_wls))
+    sparse(Is, Js, Vs, length(out_wls), length(in_wls))
 end
 
 """

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -29,6 +29,7 @@ are assumed to be in cm.
 struct Wavelengths{F,R} <: AbstractArray{F,1}
     wl_ranges::Vector{R} # in cm, not Å
     wl_ranges_Å::Vector  # original Å-scale ranges (avoids cm→Å round-trip errors)
+
     # Precomputed arrays. It may(?) be faster to lazily compute these.
     all_wls::Vector{F}
     all_freqs::Vector{F}
@@ -156,6 +157,25 @@ end
 Returns an iterator over the wavelength ranges `(λ_low, λ_hi)` in `wls` (in cm, not Å).
 """
 eachwindow(wls::Wavelengths) = ((first(r), last(r)) for r in wls.wl_ranges)
+
+"""
+    stepsize(wls::Wavelengths, i)
+
+The wavelength spacing (in cm) of the range that `wls[i]` belongs to.  `wls` can be built from
+ranges with different spacings, so this is not a single number for the whole object.  Used to turn
+a sampled profile into a quadrature weight.
+"""
+function stepsize(wls::Wavelengths, i)
+    range_lb = 1 # index into wls of the first element of the current range
+    for r in wls.wl_ranges
+        range_ub = range_lb + length(r) - 1
+        if i <= range_ub
+            return step(r)
+        end
+        range_lb = range_ub + 1
+    end
+    step(last(wls.wl_ranges))
+end
 
 """
     eachfreq(wls::Wavelengths)

--- a/src/wavelengths.jl
+++ b/src/wavelengths.jl
@@ -48,8 +48,7 @@ struct Wavelengths{F,R} <: AbstractArray{F,1}
             @warn "Korg.Wavelengths is being constructed with an abstract range type, which will hurt performance."
         end
 
-        # this could be more efficient
-        all_wls = vcat(wl_ranges...)
+        all_wls = collect(Iterators.flatten(wl_ranges)) # this allows for the eltype to be inferred
         if !issorted(all_wls)
             throw(ArgumentError("wl_ranges must be sorted and non-overlapping"))
         end
@@ -106,7 +105,7 @@ end
 # this handles the vector-of-bounds case. Each element can be a tuple of (λ_start, λ_stop) or
 # (λ_start, λ_stop, λ_step). We don't enforce tuple size here in order to make sure that  literals
 # pass correctly.
-function Wavelengths(tuples::AbstractVector{<:Tuple{Vararg{<:Real}}}, ; kwargs...)
+function Wavelengths(tuples::AbstractVector{<:Tuple{Vararg{<:Real}}}; kwargs...)
     ranges = map(tuples) do tuple
         if !(2 .<= length(tuple) .<= 3)
             throw(ArgumentError("Each wavelength range must be specified as a tuple of (λ_start, λ_stop) or (λ_start, λ_stop, λ_step). Got $tuple."))
@@ -177,11 +176,29 @@ function subspectrum_indices(wls::Wavelengths)
     wl_lb_ind = 1 # the index into α of the lowest λ in the current wavelength range
     indices = []
     for λs in wls.wl_ranges
-        wl_inds = wl_lb_ind:wl_lb_ind+length(λs)-1
+        wl_inds = wl_lb_ind:(wl_lb_ind+length(λs)-1)
         push!(indices, wl_inds)
         wl_lb_ind += length(λs)
     end
     indices
+end
+
+"""
+    clipped(wls::Wavelengths, keep::Wavelengths; pad=0.0)
+
+Return a new `Wavelengths` containing the points of `wls` which lie within `pad` (in cm) of one of
+the wavelength ranges of `keep`, or `nothing` if there are none.  Only the extent of `keep`'s
+ranges matters, not their spacing.  The underlying ranges of `wls` are sliced, so the grid values
+are preserved exactly.
+"""
+function clipped(wls::Wavelengths, keep::Wavelengths; pad=0.0)
+    # dilate each window of `keep` by `pad`, merging any that then overlap or touch, so that
+    # the slices taken below can't overlap
+    merged, _ = merge_bounds([(λ_lo - pad, λ_hi + pad) for (λ_lo, λ_hi) in eachwindow(keep)])
+    sub_ranges = [r[searchsortedfirst(r, λ_lo):searchsortedlast(r, λ_hi)]
+                  for r in wls.wl_ranges for (λ_lo, λ_hi) in merged]
+    filter!(!isempty, sub_ranges)
+    isempty(sub_ranges) ? nothing : Wavelengths(sub_ranges)
 end
 
 # index of the first element greater than or equal to λ

--- a/test/molecular_cross_sections.jl
+++ b/test/molecular_cross_sections.jl
@@ -12,7 +12,11 @@
 
     wls = [15020:0.01:15025, 15030:0.01:15035]
 
-    table = Korg.MolecularCrossSection(water_lines, wls)
+    # a couple vmic kernels broader
+    table_wls = [15019:0.01:15026, 15029:0.01:15036]
+
+    table = Korg.MolecularCrossSection(water_lines, table_wls)
+    @test !Korg.is_vmic_gridded(table) # not legacy version
 
     # this test fails if I truncate the atmosphere to 40:43, which _may_ indicate that it's worth
     # better understanding the precision of interpolation here
@@ -21,17 +25,87 @@
     filename = tempname()
     Korg.save_molecular_cross_section(filename, table)
     deserialized_table = Korg.read_molecular_cross_section(filename)
+    @test !Korg.is_vmic_gridded(deserialized_table) # not legacy version
     @test table.itp.itp.coefs == deserialized_table.itp.itp.coefs
     @test all(table.wls .≈ deserialized_table.wls)
     @test table.species == deserialized_table.species
 
     depth_dependent_vmics = fill(0.5, length(atm.layers))
     depth_dependent_vmics[20:end] .= 1.0
-    @testset for vmic in [0.5, depth_dependent_vmics]
+    @testset for vmic in [0.5, 1.2, depth_dependent_vmics]
         sol_without = synthesize(atm, linelist, format_A_X(), wls; vmic=vmic)
         sol_with = synthesize(atm, linelist_less_water, format_A_X(), wls;
                               molecular_cross_sections=[deserialized_table], vmic=vmic)
 
         @test assert_allclose(sol_without.flux, sol_with.flux; rtol=1e-3)
+    end
+
+    @testset "vmic differentiability" begin
+        Ts = [3500.0, 4500.0]
+
+        number_densities = Dict(Korg.species"H2O" => [1e10, 1e10])
+        function convolved_alpha(vmic, wavelengths)
+            α = zeros(promote_type(typeof(vmic), Float64), length(Ts), length(wavelengths))
+            Korg.interpolate_molecular_cross_sections!(α, [table], wavelengths, Ts, vmic,
+                                                       number_densities)
+            sum(α) # arbitrary, just to give the function a scalar output
+        end
+
+        # (single wavelength is like the reference wavelength in anchored radiative transfer)
+        for wavelengths in Korg.Wavelengths.([wls, [15022.0]])
+            function f(vmic)
+                α = zeros(promote_type(typeof(vmic), Float64), length(Ts), length(wavelengths))
+                Korg.interpolate_molecular_cross_sections!(α, [table], wavelengths, Ts, vmic,
+                                                           number_densities)
+                sum(α) # arbitrary, just to give the function a scalar output
+            end
+
+            f = vmic -> convolved_alpha(vmic, wavelengths)
+            @test ForwardDiff.derivative(f, 1.0) ≈
+                  FiniteDiff.finite_difference_derivative(f, 1.0) rtol=1e-6
+
+            # the derivative with respect to vmic vanishes at vmic = 0
+            @test ForwardDiff.derivative(f, 0.0) == 0
+            # for kernels narrower than the table spacing (vmic below ~0.04 km/s here), the
+            # cross-section is interpolated without broadening and the derivative is taken as 0
+            @test f(0.01) == f(0.0)
+            @test ForwardDiff.derivative(f, 0.01) == 0
+        end
+    end
+
+    @testset "tables with too-coarse wl sampling error" begin
+        coarse_table = Korg.MolecularCrossSection(water_lines, 15019:0.02:15026)
+        Ts = [3500.0, 4500.0]
+        number_densities = Dict(Korg.species"H2O" => [1e10, 1e10])
+        synth_wls = Korg.Wavelengths(15020:0.01:15025)
+        α = zeros(length(Ts), length(synth_wls))
+        @test_throws ArgumentError Korg.interpolate_molecular_cross_sections!(α, [coarse_table],
+                                                                              synth_wls, Ts, 1.0,
+                                                                              number_densities)
+
+        # single-wavelength requests have no spacing, so any table is acceptable
+        α_ref = zeros(length(Ts), 1)
+        Korg.interpolate_molecular_cross_sections!(α_ref, [coarse_table],
+                                                   Korg.Wavelengths([15022.0]), Ts, 1.0,
+                                                   number_densities)
+        @test all(α_ref .> 0)
+    end
+
+    @testset "legacy vmic-gridded tables" begin
+        legacy_table = Korg.MolecularCrossSection(water_lines, table_wls;
+                                                  vmic_vals=[0.0, 0.5, 1.0])
+        @test Korg.is_vmic_gridded(legacy_table)
+
+        tmp = tempname()
+        Korg.save_molecular_cross_section(tmp, legacy_table)
+        deserialized_legacy = Korg.read_molecular_cross_section(tmp)
+
+        @test Korg.is_vmic_gridded(deserialized_legacy)
+        @test legacy_table.itp.itp.coefs == deserialized_legacy.itp.itp.coefs
+
+        sol_without = synthesize(atm, linelist, format_A_X(), wls; vmic=0.5)
+        sol_legacy = synthesize(atm, linelist_less_water, format_A_X(), wls;
+                                molecular_cross_sections=[deserialized_legacy], vmic=0.5)
+        @test assert_allclose(sol_without.flux, sol_legacy.flux; rtol=1e-3)
     end
 end

--- a/test/molecular_cross_sections.jl
+++ b/test/molecular_cross_sections.jl
@@ -61,8 +61,8 @@
             end
 
             f = vmic -> convolved_alpha(vmic, wavelengths)
-            @test ForwardDiff.derivative(f, 1.0) ≈
-                  FiniteDiff.finite_difference_derivative(f, 1.0) rtol=1e-6
+            @test ForwardDiff.derivative(f, 1.0)≈
+            FiniteDiff.finite_difference_derivative(f, 1.0) rtol=1e-6
 
             # the derivative with respect to vmic vanishes at vmic = 0
             @test ForwardDiff.derivative(f, 0.0) == 0

--- a/test/molecular_cross_sections.jl
+++ b/test/molecular_cross_sections.jl
@@ -31,7 +31,7 @@
     @test table.species == deserialized_table.species
 
     depth_dependent_vmics = fill(0.5, length(atm.layers))
-    depth_dependent_vmics[20:end] .= 1.0
+    depth_dependent_vmics[20:end] .= 0.0
     @testset for vmic in [0.5, 1.2, depth_dependent_vmics]
         sol_without = synthesize(atm, linelist, format_A_X(), wls; vmic=vmic)
         sol_with = synthesize(atm, linelist_less_water, format_A_X(), wls;

--- a/test/molecular_cross_sections.jl
+++ b/test/molecular_cross_sections.jl
@@ -53,13 +53,6 @@
 
         # (single wavelength is like the reference wavelength in anchored radiative transfer)
         for wavelengths in Korg.Wavelengths.([wls, [15022.0]])
-            function f(vmic)
-                α = zeros(promote_type(typeof(vmic), Float64), length(Ts), length(wavelengths))
-                Korg.interpolate_molecular_cross_sections!(α, [table], wavelengths, Ts, vmic,
-                                                           number_densities)
-                sum(α) # arbitrary, just to give the function a scalar output
-            end
-
             f = vmic -> convolved_alpha(vmic, wavelengths)
             @test ForwardDiff.derivative(f, 1.0)≈
             FiniteDiff.finite_difference_derivative(f, 1.0) rtol=1e-6

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -38,12 +38,15 @@
               Korg.compute_LSF_matrix(range_wls, obs_wls, R)
 
         convF = Korg.apply_LSF(flux, wls, R)
-        convF_5sigma = Korg.apply_LSF(flux, wls, R; window_size=5)
+        convF5 = Korg.apply_LSF(flux, wls, R; window_size=5)
         convF_mat = Korg.compute_LSF_matrix(wls, wls, R) * flux
         convF_mat5 = Korg.compute_LSF_matrix(wls, wls, R; window_size=5) * flux
         convF_mat_vec = Korg.compute_LSF_matrix([5900:0.35:5935, 5935.35:0.35:6100], wls, R) * flux
         convF_changing_R = Korg.apply_LSF(flux, wls, wl -> wl / 6000 * R)
         convF_mat_changing_R = Korg.compute_LSF_matrix(wls, wls, wl -> wl / 6000 * R) * flux
+
+        @test convF ≈ convF_mat
+        @test convF5 ≈ convF_mat5
 
         @test convF_mat_changing_R≈convF_changing_R rtol=1e-10
 
@@ -53,7 +56,7 @@
 
         # normalized?
         @test sum(flux)≈sum(convF) rtol=1e-3
-        @test sum(flux)≈sum(convF_5sigma) rtol=1e-3
+        @test sum(flux)≈sum(convF5) rtol=1e-3
         @test sum(flux)≈sum(convF_mat) rtol=1e-3
         @test sum(flux)≈sum(convF_mat5) rtol=1e-3
         @test sum(flux)≈sum(convF_mat5) rtol=1e-3
@@ -64,7 +67,7 @@
 
         # preserves line center?
         @test argmax(convF) == spike_ind
-        @test argmax(convF_5sigma) == spike_ind
+        @test argmax(convF5) == spike_ind
         @test argmax(convF_mat) == spike_ind
         @test argmax(convF_mat5) == spike_ind
         @test argmax(convF_mat_vec) == spike_ind
@@ -73,11 +76,11 @@
 
         # make sure the default window_size values are OK
         @test assert_allclose(convF, convF_mat5; atol=1e-4)
-        @test assert_allclose(convF_5sigma, convF_mat5; rtol=1e-11)
+        @test assert_allclose(convF5, convF_mat5; rtol=1e-11)
         @test assert_allclose(convF_mat, convF_mat5; atol=1e-4)
 
         # but also check that they are definitely doing something
-        @test !(convF ≈ convF_5sigma)
+        @test !(convF ≈ convF5)
         @test !(convF_mat ≈ convF_mat5)
     end
 

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -1,5 +1,4 @@
 @testset "Wavelengths" begin
-
     @testset "constructor" begin
         @test_throws "wavelengths must be non-empty" Korg.Wavelengths([])
 

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -136,4 +136,26 @@
         @test only(Base.return_types(Korg.clipped, (typeof(wls), typeof(wls)))) ==
               Union{Nothing,typeof(wls)}
     end
+
+    @testset "stepsize" begin
+        # single range: every index has the same spacing, in cm
+        wls = Korg.Wavelengths(5000:0.01:5010)
+        @test all(Korg.stepsize(wls, i) ≈ 0.01e-8 for i in eachindex(wls))
+
+        # ranges with different spacings: each index gets the step of its own range.
+        # 5000:0.01:5010 is 1001 points, so indices 1:1001 are the first range and
+        # 1002:1502 (6000:0.02:6010, 501 points) are the second.
+        wls = Korg.Wavelengths([5000:0.01:5010, 6000:0.02:6010])
+        @test Korg.stepsize(wls, 1) ≈ 0.01e-8
+        @test Korg.stepsize(wls, 1001) ≈ 0.01e-8   # last point of the first range
+        @test Korg.stepsize(wls, 1002) ≈ 0.02e-8   # first point of the second range
+        @test Korg.stepsize(wls, 1502) ≈ 0.02e-8
+
+        # the step changes exactly at the range boundary, and nowhere else
+        steps = [Korg.stepsize(wls, i) for i in eachindex(wls)]
+        @test findall(diff(steps) .!= 0) == [1001]
+
+        # type stability: the return type matches the wavelength eltype
+        @test only(Base.return_types(Korg.stepsize, (typeof(wls), Int))) == eltype(wls)
+    end
 end

--- a/test/wavelengths.jl
+++ b/test/wavelengths.jl
@@ -1,4 +1,5 @@
 @testset "Wavelengths" begin
+
     @testset "constructor" begin
         @test_throws "wavelengths must be non-empty" Korg.Wavelengths([])
 
@@ -101,5 +102,39 @@
         freqs = Korg.eachfreq(wls)
         @test issorted(freqs)
         @test length(freqs) == length(wls)
+    end
+
+    @testset "clipped" begin
+        wls = Korg.Wavelengths([5000:0.01:5010, 5020:0.01:5030])
+
+        # boundaries chosen between wls grid points, so the tests are robust to roundoff
+        sub = Korg.clipped(wls, Korg.Wavelengths(5004.995:0.01:5025.005))
+        @test sub ≈ Korg.Wavelengths([5005:0.01:5010, 5020:0.01:5025])
+        # clipping slices the wavelengths rather than reconstructing them
+        @test all(in(wls), sub)
+
+        # pad (in cm) dilates the kept windows
+        sub = Korg.clipped(wls, Korg.Wavelengths(5005:0.01:5007); pad=1.005e-8)
+        @test sub ≈ Korg.Wavelengths(5004:0.01:5008)
+
+        # windows entirely within a gap or outside the wavelengths yield nothing
+        @test isnothing(Korg.clipped(wls, Korg.Wavelengths(5012:0.01:5018)))
+        @test isnothing(Korg.clipped(wls, Korg.Wavelengths(4000:0.01:4500)))
+
+        # a contiguous Wavelengths clipped with a multi-window keep becomes multi-range
+        contiguous = Korg.Wavelengths(6000:0.01:6100)
+        sub = Korg.clipped(contiguous, Korg.Wavelengths([6010:0.01:6020, 6050:0.01:6060]);
+                           pad=0.005e-8)
+        @test sub ≈ Korg.Wavelengths([6010:0.01:6020, 6050:0.01:6060])
+
+        # windows which overlap after padding are merged
+        sub = Korg.clipped(contiguous, Korg.Wavelengths([6010:0.01:6020, 6020.5:0.01:6030]);
+                           pad=1.005e-8)
+        @test sub ≈ Korg.Wavelengths(6009:0.01:6031)
+
+        # clipped and the constructor it calls are type-stable (up to `nothing`),
+        @test isconcretetype(only(Base.return_types(Korg.Wavelengths, (typeof(wls.wl_ranges),))))
+        @test only(Base.return_types(Korg.clipped, (typeof(wls), typeof(wls)))) ==
+              Union{Nothing,typeof(wls)}
     end
 end


### PR DESCRIPTION
Korg's `MolecularCrossSection`s provide a way to precompute the total per-particle absorption coefficient across wavelengths (and other relevant params) for a given molecule. This allows you to spend time up front to get much faster synthesis later. For water lines in APOGEE this is a roughly 10x difference!

Until now the precomputed cross sections were computed and interpolated across three dimensions: wavelength, temperature, and vmic. (Korg neglects pressure broadening of molecular lines, though #544 aims to change that.) This PR drops vmic, and convolves the cross-sections at runtime instead. This makes the cross-sections about 15x smaller (and 15x cheaper to compute). It is also more accurate, but this is negligible. The runtime speed benchmarks do not show a statistically significant difference.

Accuracy is not changed from the previous implementation. I have turned down the default alpha cutoff threshold to be slightly less conservative (this effect is not included in perf statements above).
<img width="1349" height="526" alt="image" src="https://github.com/user-attachments/assets/86d15a03-41b7-4274-884e-05f79ebf1df1" />
